### PR TITLE
Add hero teaser video playback

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,8 +23,21 @@ export default function Page() {
             </a>
           </div>
           <div className="mt-10 aspect-video w-full rounded-2xl overflow-hidden border border-white/10">
-            {/* Ide mehet egy némított webm teaser posztbuild után */}
-            <img src="https://media.aikaworld.com/hero-keyart.jpg" alt="AIKA World key art" className="w-full h-full object-cover" />
+            <video
+              className="h-full w-full object-cover"
+              autoPlay
+              muted
+              loop
+              playsInline
+              poster="https://media.aikaworld.com/teaser/teaser-poster.jpg"
+            >
+              <source src="https://media.aikaworld.com/teaser/teaser.webm" type="video/webm" />
+              <img
+                src="https://media.aikaworld.com/teaser/teaser-poster.jpg"
+                alt="AIKA World teaser poster"
+                className="h-full w-full object-cover"
+              />
+            </video>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- replace the hero key art image with an autoplaying teaser video that loops inline
- add a poster and inline image fallback so the hero still displays if the video fails to load

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db8ddb810083259c2fc2605ad4e4ad