### PR TITLE
Add characters index and profile pages

### DIFF
--- a/app/characters/[slug]/page.tsx
+++ b/app/characters/[slug]/page.tsx
@@ -1,0 +1,115 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { characters, getCharacter } from '../data';
+
+type CharacterPageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+export function generateMetadata({ params }: CharacterPageProps): Metadata {
+  const character = getCharacter(params.slug);
+
+  if (!character) {
+    return {
+      title: 'Ismeretlen rezonátor – AIKA World'
+    };
+  }
+
+  return {
+    title: `${character.name} – ${character.title} | AIKA World`,
+    description: `${character.name} részletes profilja: ${character.role}, ${character.element} elem, játékmenet – tippek raidhez.`,
+    openGraph: {
+      title: `${character.name} – ${character.title}`,
+      description: `${character.role} ${character.element} rezonátor a csapatban.`,
+      images: [
+        {
+          url: character.heroImage,
+          width: 1280,
+          height: 720,
+          alt: `${character.name} hero bannere`
+        }
+      ]
+    }
+  };
+}
+
+export function generateStaticParams() {
+  return characters.map(character => ({ slug: character.slug }));
+}
+
+export default function CharacterPage({ params }: CharacterPageProps) {
+  const character = getCharacter(params.slug);
+
+  if (!character) {
+    notFound();
+  }
+
+  return (
+    <div>
+      <section className="relative isolate">
+        <div className="absolute inset-0 -z-10">
+          <img
+            src={character.heroImage}
+            alt={`${character.name} hero banner`}
+            className="h-full w-full object-cover"
+          />
+          <div className="absolute inset-0 bg-black/60" />
+        </div>
+        <div className="mx-auto max-w-6xl px-4 py-24">
+          <nav aria-label="breadcrumb" className="text-sm text-white/80">
+            <ol className="flex items-center gap-2">
+              <li>
+                <Link href="/characters" className="hover:opacity-80">
+                  Characters
+                </Link>
+              </li>
+              <li aria-hidden>/</li>
+              <li className="font-medium text-white">{character.name}</li>
+            </ol>
+          </nav>
+          <div className="mt-6 max-w-2xl">
+            <p className="text-sm uppercase tracking-[0.3em] text-accentB">{character.title}</p>
+            <h1 className="mt-3 text-4xl md:text-5xl font-bold">{character.name}</h1>
+            <p className="mt-4 text-lg text-white/90">{character.playstyle}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-12">
+        <div className="grid gap-8 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
+            <h2 className="text-lg font-semibold">Archetípus</h2>
+            <dl className="mt-4 space-y-3 text-sm">
+              <div>
+                <dt className="opacity-60">Szerep</dt>
+                <dd className="font-medium">{character.role}</dd>
+              </div>
+              <div>
+                <dt className="opacity-60">Elem</dt>
+                <dd className="font-medium">{character.element}</dd>
+              </div>
+              <div>
+                <dt className="opacity-60">Játékmód</dt>
+                <dd className="font-medium">{character.playstyle}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className="rounded-2xl border border-accentB/30 bg-accentB/10 p-6">
+            <h2 className="text-lg font-semibold">Tippgyűjtemény</h2>
+            <ul className="mt-4 list-disc list-inside space-y-2 text-sm">
+              {character.tips.map(tip => (
+                <li key={tip} className="opacity-90">
+                  {tip}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/characters/data.ts
+++ b/app/characters/data.ts
@@ -1,0 +1,85 @@
+export type Character = {
+  slug: string;
+  name: string;
+  title: string;
+  heroImage: string;
+  role: string;
+  element: string;
+  playstyle: string;
+  tips: string[];
+};
+
+export const characters: Character[] = [
+  {
+    slug: 'akari',
+    name: 'Akari',
+    title: 'Blazeblade Vanguard',
+    heroImage: 'https://media.aikaworld.com/characters/akari-banner.jpg',
+    role: 'Frontvonal DPS',
+    element: 'Tűz',
+    playstyle: 'Közelharci ütemre épülő burst kombók, magas mozgékonysággal.',
+    tips: [
+      'A rezgésmérő feltöltése után mindig kezdd a Forgestep dashsel a maximális égési töltetekhez.',
+      'A boss fázisváltásai alatt a Pyreguard pajzs aktiválása csapatvédelemmé válik – szólítsd össze a party-t.',
+      'A tűz tornádó ultit a csapat kontrollja után dobd be, így biztosan bent maradnak az ellenfelek a sebzésmezőben.'
+    ]
+  },
+  {
+    slug: 'komi',
+    name: 'Komi',
+    title: 'Tideweaver Oracle',
+    heroImage: 'https://media.aikaworld.com/characters/komi-banner.jpg',
+    role: 'Támogató kontroll',
+    element: 'Víz',
+    playstyle: 'Távolsági crowd-control, erős cleanse és reaktív buffok.',
+    tips: [
+      'Az árapály mezőt tartsd a csapat alatt; mozgó harcban használj hullám dash-t, hogy velük együtt sodródjon.',
+      'A Purge Bubble megszakítja a legtöbb debuffot – időzítsd a raid mechanikákhoz.',
+      'Energizáld a fő DPS-t az Ebbflow buffal, mielőtt az ultija elkezdődik, így duplázódik a sebzésablaka.'
+    ]
+  },
+  {
+    slug: 'yui',
+    name: 'Yui',
+    title: 'Gale Dancer',
+    heroImage: 'https://media.aikaworld.com/characters/yui-banner.jpg',
+    role: 'Mobility DPS',
+    element: 'Szél',
+    playstyle: 'Légi kombók, folyamatos kitérés és DOT sebzés.',
+    tips: [
+      'A Skystring grapplinggel láncold össze a levegőben töltött időt, így aktiválod a Cyclone perk bónuszát.',
+      'A Zephyr Mark felhalmozódik, ha külön célpontokat érintesz – területi fázisokban váltogasd az ellenfeleket.',
+      'Ultid előtt mindig használd a Breeze Step-et, hogy a következő három találat garantált crit legyen.'
+    ]
+  },
+  {
+    slug: 'hina',
+    name: 'Hina',
+    title: 'Edge Serenade',
+    heroImage: 'https://media.aikaworld.com/characters/hina-banner.jpg',
+    role: 'Assassin Burst',
+    element: 'Penge',
+    playstyle: 'Gyors kivégző rotáció, stealth alapú reposition.',
+    tips: [
+      'A Shadow Veil után az első találat garantáltan megkettőződik – ezt a boss sebezhető ablakaiban használd ki.',
+      'Az Echo Slash stackjeit akkor veszíti el, ha találatot kapsz, ezért a dash iframe-jeivel játssz agresszívan.',
+      'A finisher animációja cancellálható a Serenade Waltz dash-sel, így gyorsabban léphetsz ki a veszélyes zónákból.'
+    ]
+  },
+  {
+    slug: 'miyu',
+    name: 'Miyu',
+    title: 'Luminous Aegis',
+    heroImage: 'https://media.aikaworld.com/characters/miyu-banner.jpg',
+    role: 'Gyógyító pajzsfókusz',
+    element: 'Fény',
+    playstyle: 'Állandó pajzsmenedzsment és időzített burst heal.',
+    tips: [
+      'A Radiant Ward pajzsok stackelődnek – cseréld rotáció szerint a party tagok között, hogy mindenkinek maradjon.',
+      'A Solaris Pulse heal akkor a legerősebb, ha 3 fénygömb aktív – készülj fel előre a nagy sebzés hullámokra.',
+      'A Sanctuary Field mozdíthatatlan, ezért a csapat előre jelzett pozíciójához állítsd be, mielőtt a mechanika kezdődik.'
+    ]
+  }
+];
+
+export const getCharacter = (slug: string) => characters.find(character => character.slug === slug);

--- a/app/characters/page.tsx
+++ b/app/characters/page.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import { characters } from './data';
+
+export const metadata = {
+  title: 'Rezonátorok – AIKA World',
+  description: 'Akari, Komi, Yui, Hina és Miyu részletes karakterprofilja az AIKA World világából.'
+};
+
+export default function CharactersPage() {
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-16">
+      <div className="mb-10">
+        <nav aria-label="breadcrumb" className="text-sm opacity-70">
+          <ol className="flex items-center gap-2">
+            <li>
+              <Link href="/characters" className="hover:opacity-80">
+                Characters
+              </Link>
+            </li>
+          </ol>
+        </nav>
+        <h1 className="mt-4 text-3xl md:text-4xl font-bold">AIKA World Rezonátorok</h1>
+        <p className="mt-3 max-w-2xl opacity-90">
+          Ismerd meg mind az öt fő karakter képességeit, szerepeit és legjobb gyakorlati tippjeit, mielőtt belépsz a raid arénákba.
+        </p>
+      </div>
+
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {characters.map(character => (
+          <article
+            key={character.slug}
+            className="rounded-2xl border border-white/10 bg-white/5 overflow-hidden shadow-lg shadow-black/20"
+          >
+            <div className="aspect-[16/9] w-full overflow-hidden">
+              <img
+                src={character.heroImage}
+                alt={`${character.name} hero art`}
+                className="h-full w-full object-cover"
+              />
+            </div>
+            <div className="p-6">
+              <h2 className="text-xl font-semibold">{character.name}</h2>
+              <p className="text-sm uppercase tracking-wide opacity-70">{character.title}</p>
+              <dl className="mt-4 grid grid-cols-2 gap-4 text-sm">
+                <div>
+                  <dt className="opacity-60">Szerep</dt>
+                  <dd className="font-medium">{character.role}</dd>
+                </div>
+                <div>
+                  <dt className="opacity-60">Elem</dt>
+                  <dd className="font-medium">{character.element}</dd>
+                </div>
+              </dl>
+              <p className="mt-4 text-sm opacity-80">{character.playstyle}</p>
+              <Link
+                href={`/characters/${character.slug}`}
+                className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-accentB hover:opacity-80"
+              >
+                Profil megnyitása
+                <span aria-hidden>→</span>
+              </Link>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <a href="/" className="font-semibold tracking-wide">AIKA WORLD</a>
             <nav className="flex gap-4 text-sm">
               <a href="#modes" className="hover:opacity-80">Játékmódok</a>
-              <a href="#characters" className="hover:opacity-80">Karakterek</a>
+              <a href="/characters" className="hover:opacity-80">Karakterek</a>
               <a href="#media" className="hover:opacity-80">Média</a>
               <a href="#roadmap" className="hover:opacity-80">Roadmap</a>
               <a href="#community" className="hover:opacity-80">Közösség</a>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-24 text-center">
+      <div className="text-sm uppercase tracking-[0.3em] text-accentB">404</div>
+      <h1 className="mt-3 text-3xl md:text-4xl font-bold">Ez a rezgés nem létezik</h1>
+      <p className="mt-4 opacity-80">
+        Úgy tűnik, egy olyan oldalra tévedtél, ami még nincs behangolva az AIKA World univerzumában. Nézz vissza a főoldalra vagy
+        fedezd fel a Rezonátorokat.
+      </p>
+      <div className="mt-8 flex flex-col sm:flex-row justify-center gap-3">
+        <Link href="/" className="rounded-lg border border-white/10 bg-white/5 px-4 py-2 hover:bg-white/10">
+          Vissza a főoldalra
+        </Link>
+        <Link href="/characters" className="rounded-lg bg-accentB px-4 py-2 font-semibold hover:opacity-90">
+          Rezonátorok felfedezése
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable character data along with a characters index route displaying grid cards with breadcrumb
- introduce dynamic character profile pages with hero banner, role/element/playstyle details, and tips
- provide a custom not-found experience and update the navigation to link to the characters section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db90ad466483259396e32854d820c8