### PR TITLE
Fejléc CTA-k és sticky háttér finomítása

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.next
+out

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import Header from '../components/Header';
 
 export const metadata: Metadata = {
   title: 'AIKA World – Anime co-op action RPG',
@@ -39,26 +40,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body className="min-h-dvh antialiased">
-        <header className="fixed inset-x-0 top-0 z-50 backdrop-blur bg-black/20 border-b border-white/10">
-          <div className="mx-auto max-w-6xl px-4 h-14 flex items-center justify-between">
-            <a href="/" className="font-semibold tracking-wide">AIKA WORLD</a>
-            <nav className="flex gap-4 text-sm">
-              <a href="#modes" className="hover:opacity-80">Játékmódok</a>
-              <a href="/characters" className="hover:opacity-80">Karakterek</a>
-              <a href="#media" className="hover:opacity-80">Média</a>
-              <a href="#roadmap" className="hover:opacity-80">Roadmap</a>
-              <a href="#community" className="hover:opacity-80">Közösség</a>
-            </nav>
-            <div className="hidden sm:flex gap-2">
-              <a className="px-3 py-1.5 rounded-md bg-white/10 hover:bg-white/20 text-sm" href="https://discord.gg/">
-                Join Discord
-              </a>
-              <a className="px-3 py-1.5 rounded-md bg-accentA hover:opacity-90 text-sm" href="https://store.steampowered.com/">
-                Wishlist on Steam
-              </a>
-            </div>
-          </div>
-        </header>
+        <Header />
         <main className="pt-14">{children}</main>
         <footer className="mt-24 border-t border-white/10">
           <div className="mx-auto max-w-6xl px-4 py-10 text-sm">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const SCROLL_THRESHOLD = 60;
+
+export default function Header() {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > SCROLL_THRESHOLD);
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <header
+      className={`fixed inset-x-0 top-0 z-50 border-b border-white/10 backdrop-blur transition-colors ${
+        isScrolled ? 'bg-black/60' : 'bg-black/20'
+      }`}
+    >
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+        <a href="/" className="font-semibold tracking-wide">
+          AIKA WORLD
+        </a>
+        <nav className="flex gap-4 text-sm">
+          <a href="#modes" className="hover:opacity-80">
+            Játékmódok
+          </a>
+          <a href="/characters" className="hover:opacity-80">
+            Karakterek
+          </a>
+          <a href="#media" className="hover:opacity-80">
+            Média
+          </a>
+          <a href="#roadmap" className="hover:opacity-80">
+            Roadmap
+          </a>
+          <a href="#community" className="hover:opacity-80">
+            Közösség
+          </a>
+        </nav>
+        <div className="hidden gap-2 sm:flex">
+          <a
+            className="rounded-md bg-accentA px-3 py-1.5 text-sm font-semibold hover:opacity-90"
+            href="https://store.steampowered.com/"
+          >
+            Wishlist on Steam
+          </a>
+          <a className="rounded-md bg-white/10 px-3 py-1.5 text-sm hover:bg-white/20" href="https://discord.gg/">
+            Join Discord
+          </a>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- létrehoztam egy kliens oldali fejléc komponenst görgetésfigyeléssel, ami 60px után sötétebbre váltja az átlátszó háttérszínt
- frissítettem a navigáció gombjait, hogy a Wishlist on Steam kapja az elsődleges (accent) stílust, a Join Discord pedig másodlagos maradjon
- bővítettem a .gitignore fájlt a build során keletkező Next.js könyvtárak kizárásához

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9d2bb9cc8325ab097ff2b8d1136c