### PR TITLE
Add privacy and terms placeholder pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import type { Metadata } from 'next';
+import Link from 'next/link';
 import Header from '../components/Header';
 
 export const metadata: Metadata = {
@@ -53,12 +54,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <main className="pt-14">{children}</main>
         <footer className="mt-24 border-t border-white/10">
           <div className="mx-auto max-w-6xl px-4 py-10 text-sm">
-            <span className="opacity-80">
-              © {new Date().getFullYear()} aikaworld.com • Privacy • Terms •
-            </span>{' '}
-            <a href="/presskit" className="opacity-80 hover:opacity-100">
+            <span className="opacity-80">© {new Date().getFullYear()} aikaworld.com • </span>
+            <Link href="/privacy" className="opacity-80 hover:opacity-100">
+              Adatkezelés
+            </Link>
+            <span className="opacity-80"> • </span>
+            <Link href="/terms" className="opacity-80 hover:opacity-100">
+              Felhasználási feltételek
+            </Link>
+            <span className="opacity-80"> • </span>
+            <Link href="/presskit" className="opacity-80 hover:opacity-100">
               Presskit
-            </a>
+            </Link>
           </div>
         </footer>
       </body>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Adatvédelmi tájékoztató – AIKA World',
+  description:
+    'Ismerd meg, hogyan kezeljük az adataidat az AIKA World világában. A részletes tájékoztató hamarosan érkezik.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16">
+      <h1 className="text-3xl font-semibold">Adatvédelmi tájékoztató</h1>
+      <p className="mt-6 text-lg opacity-80">
+        Ez egy ideiglenes szöveg, amíg a végleges adatvédelmi tájékoztatón dolgozunk.
+        A teljes dokumentum hamarosan elérhető lesz ezen az oldalon.
+      </p>
+      <p className="mt-4 opacity-80">
+        Amennyiben sürgős kérdésed merül fel, kérjük, vedd fel velünk a kapcsolatot az
+        info@aikaworld.com címen.
+      </p>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Felhasználási feltételek – AIKA World',
+  description:
+    'Tudd meg, milyen szabályok mellett vehetsz részt az AIKA World közösségében. A részletes feltételek hamarosan elérhetők.',
+};
+
+export default function TermsPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16">
+      <h1 className="text-3xl font-semibold">Felhasználási feltételek</h1>
+      <p className="mt-6 text-lg opacity-80">
+        Ez egy ideiglenes szöveg, amely a végleges felhasználási feltételek kiadásáig szolgál
+        helykitöltőként.
+      </p>
+      <p className="mt-4 opacity-80">
+        Dolgozunk azon, hogy minden részlet pontosan és érthetően megfogalmazva jelenjen meg
+        ezen az oldalon. Köszönjük a türelmed!
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated privacy and terms pages with temporary Hungarian copy and SEO metadata
- link the new pages from the global footer alongside the presskit link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbaa4cb3b4832581927ad5fe3cd4ec