### PR TITLE
Update README with localisation guidance

### DIFF
--- a/docs/content-owners-guide.md
+++ b/docs/content-owners-guide.md
@@ -1,0 +1,23 @@
+# Content Owner's Guide
+
+## Requesting a Commercial Licence
+
+1. Prepare a detailed brief that covers: project description, distribution channels, territories, projected timelines, revenue model and any third-party partners.
+2. Email the brief to `legal@aikaworld.com` with the subject line `Commercial Licence Request`. Include your full legal entity name, billing address and preferred contact person.
+3. Expect an acknowledgement within 3 business days. The legal team typically issues a draft agreement or follow-up questions within 14 business days.
+4. Do not publish, sell or promote any AIKA World materials until a signed licence agreement has been executed.
+
+## Reporting Infringement
+
+1. Collect URLs, screenshots and any relevant transaction records that demonstrate the suspected infringement.
+2. Submit the evidence to `legal@aikaworld.com` with the subject line `Infringement Report`.
+3. Provide your contact information so the legal team can request clarifications if needed.
+4. For urgent takedowns on third-party platforms, file a DMCA notice using the platform's tools and CC the legal address above for tracking.
+
+## Using the Fan Content Policy
+
+1. Review the policy at `https://aikaworld.com/legal/fan-content` (Hungarian version: `https://aikaworld.com/hu/legal/fan-content`).
+2. Clearly mark your creation as "Unofficial AIKA World fan work" and avoid confusing it with official releases.
+3. Keep projects non-commercial unless you have obtained a written licence. No paid ads, crowdfunding or merchandise sales are allowed under the fan rules.
+4. Follow the conduct rules outlined in the policy (no hate speech, harassment or misuse of trademarks).
+5. When in doubt, email `legal@aikaworld.com` for clarification before publishing.


### PR DESCRIPTION
## Summary
- rewrite the README in English with expanded guidance on i18n usage, translation workflow, legal content maintenance, media watermarking, and archiving
- add a Content Owner's Guide that outlines licensing requests, infringement reports, and applying the fan policy

## Testing
- npm run validate:translations

------
https://chatgpt.com/codex/tasks/task_e_68dd14a0de248325b68681ff9eec12ff