### PR TITLE
Handle missing optional env URLs gracefully

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -9,8 +9,8 @@ const SCROLL_THRESHOLD = 60;
 const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
 
 type HeaderProps = {
-  steamUrl: string;
-  discordUrl: string;
+  steamUrl: string | null;
+  discordUrl: string | null;
   locale: Locale;
   dictionary: HeaderDictionary;
 };
@@ -105,15 +105,19 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
             ))}
           </select>
           <div className="hidden gap-2 sm:flex">
-            <a
-              className="rounded-md bg-accentA px-3 py-1.5 text-sm font-semibold hover:opacity-90"
-              href={steamUrl}
-            >
-              {dictionary.wishlistCta}
-            </a>
-            <a className="rounded-md bg-white/10 px-3 py-1.5 text-sm hover:bg-white/20" href={discordUrl}>
-              {dictionary.discordCta}
-            </a>
+            {steamUrl && (
+              <a
+                className="rounded-md bg-accentA px-3 py-1.5 text-sm font-semibold hover:opacity-90"
+                href={steamUrl}
+              >
+                {dictionary.wishlistCta}
+              </a>
+            )}
+            {discordUrl && (
+              <a className="rounded-md bg-white/10 px-3 py-1.5 text-sm hover:bg-white/20" href={discordUrl}>
+                {dictionary.discordCta}
+              </a>
+            )}
           </div>
         </div>
       </div>

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -15,8 +15,8 @@ type SubscribeResponse = {
 };
 
 type HomePageProps = {
-  steamUrl: string;
-  discordUrl: string;
+  steamUrl: string | null;
+  discordUrl: string | null;
   locale: Locale;
   dictionary: HomeDictionary;
   lightboxDictionary: LightboxDictionary;
@@ -109,12 +109,16 @@ export default function HomePage({
             {dictionary.hero.description}
           </p>
           <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
-            <a className="px-5 py-3 rounded-lg bg-accentA hover:opacity-90 font-semibold" href={steamUrl}>
-              {dictionary.hero.wishlistCta}
-            </a>
-            <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href={discordUrl}>
-              {dictionary.hero.discordCta}
-            </a>
+            {steamUrl && (
+              <a className="px-5 py-3 rounded-lg bg-accentA hover:opacity-90 font-semibold" href={steamUrl}>
+                {dictionary.hero.wishlistCta}
+              </a>
+            )}
+            {discordUrl && (
+              <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href={discordUrl}>
+                {dictionary.hero.discordCta}
+              </a>
+            )}
             <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href="#newsletter">
               {dictionary.hero.subscribeCta}
             </a>
@@ -240,12 +244,16 @@ export default function HomePage({
         <h2 className="text-2xl md:text-3xl font-bold">{dictionary.community.title}</h2>
         <p className="mt-2 opacity-90">{dictionary.community.description}</p>
         <div className="mt-6 flex flex-col sm:flex-row gap-3">
-          <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href={discordUrl}>
-            {dictionary.community.discordCta}
-          </a>
-          <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href={steamUrl}>
-            {dictionary.community.wishlistCta}
-          </a>
+          {discordUrl && (
+            <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href={discordUrl}>
+              {dictionary.community.discordCta}
+            </a>
+          )}
+          {steamUrl && (
+            <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href={steamUrl}>
+              {dictionary.community.wishlistCta}
+            </a>
+          )}
         </div>
 
         <form id="newsletter" className="mt-6 max-w-md" onSubmit={handleSubmit}>

--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -1,6 +1,7 @@
-const requiredEnv = ['STEAM_URL', 'DISCORD_URL', 'SITE_URL'] as const;
+const requiredEnv = ['SITE_URL'] as const;
+const optionalEnv = ['STEAM_URL', 'DISCORD_URL'] as const;
 
-function readEnv(name: (typeof requiredEnv)[number]) {
+function readRequiredEnv(name: (typeof requiredEnv)[number]) {
   const value = process.env[name];
   if (!value) {
     throw new Error(`Missing required environment variable: ${name}`);
@@ -8,10 +9,15 @@ function readEnv(name: (typeof requiredEnv)[number]) {
   return value;
 }
 
+function readOptionalEnv(name: (typeof optionalEnv)[number]) {
+  const value = process.env[name];
+  return value && value.trim().length > 0 ? value : null;
+}
+
 export const serverEnv = {
-  steamUrl: readEnv('STEAM_URL'),
-  discordUrl: readEnv('DISCORD_URL'),
-  siteUrl: readEnv('SITE_URL')
+  steamUrl: readOptionalEnv('STEAM_URL'),
+  discordUrl: readOptionalEnv('DISCORD_URL'),
+  siteUrl: readRequiredEnv('SITE_URL')
 } as const;
 
 export type ServerEnv = typeof serverEnv;


### PR DESCRIPTION
## Summary
- make STEAM_URL and DISCORD_URL optional so builds do not crash when they are unset
- hide Steam and Discord CTAs in the header and homepage when their links are unavailable

## Testing
- CI=1 SITE_URL=https://example.com npm run build:next

------
https://chatgpt.com/codex/tasks/task_e_68dd2ee2e5ac83259523927d239667e9