### PR TITLE
Handle missing SITE_URL with sensible fallbacks

### DIFF
--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -1,23 +1,45 @@
-const requiredEnv = ['SITE_URL'] as const;
 const optionalEnv = ['STEAM_URL', 'DISCORD_URL'] as const;
-
-function readRequiredEnv(name: (typeof requiredEnv)[number]) {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-}
 
 function readOptionalEnv(name: (typeof optionalEnv)[number]) {
   const value = process.env[name];
   return value && value.trim().length > 0 ? value : null;
 }
 
+function ensureProtocol(url: string) {
+  if (/^https?:\/\//i.test(url)) {
+    return url;
+  }
+  return `https://${url}`;
+}
+
+function resolveSiteUrl() {
+  const candidates = [
+    process.env.SITE_URL,
+    process.env.NEXT_PUBLIC_SITE_URL,
+    process.env.VERCEL_URL,
+    process.env.DEPLOY_PRIME_URL,
+    process.env.DEPLOY_URL,
+    process.env.URL
+  ];
+
+  for (const candidate of candidates) {
+    if (candidate && candidate.trim().length > 0) {
+      return ensureProtocol(candidate.trim());
+    }
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    return 'http://localhost:3000';
+  }
+
+  console.warn('[server-config] Missing SITE_URL environment variable. Falling back to https://aikaworld.com');
+  return 'https://aikaworld.com';
+}
+
 export const serverEnv = {
   steamUrl: readOptionalEnv('STEAM_URL'),
   discordUrl: readOptionalEnv('DISCORD_URL'),
-  siteUrl: readRequiredEnv('SITE_URL')
+  siteUrl: resolveSiteUrl()
 } as const;
 
 export type ServerEnv = typeof serverEnv;


### PR DESCRIPTION
## Summary
- add support for deriving SITE_URL from common deployment environment variables
- provide a localhost default in development and log a warning fallback for production deployments

## Testing
- not run (build command requires the tsx binary which is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd4a45e2d4832582972fd5341a4b1a