### PR TITLE
Handle async locale resolution for Next.js headers

### DIFF
--- a/app/characters/[slug]/page.tsx
+++ b/app/characters/[slug]/page.tsx
@@ -4,7 +4,6 @@ import { notFound } from 'next/navigation';
 import SiteLayout from '../../../components/SiteLayout';
 import { getCharacter, characterSlugs } from '../../../lib/content/characters';
 import { getDictionary } from '../../../lib/i18n/dictionaries';
-import type { Locale } from '../../../lib/i18n/config';
 import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
 import { createCharacterMetadata, createStaticPageMetadata } from '../../../lib/seo';
 
@@ -22,7 +21,7 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: CharacterPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const locale = resolveRequestLocale() as Locale;
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const character = getCharacter(locale, slug);
 
@@ -35,7 +34,7 @@ export async function generateMetadata({ params }: CharacterPageProps): Promise<
 
 export default async function CharacterPage({ params }: CharacterPageProps) {
   const { slug } = await params;
-  const locale = resolveRequestLocale() as Locale;
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const character = getCharacter(locale, slug);
 

--- a/app/characters/page.tsx
+++ b/app/characters/page.tsx
@@ -3,18 +3,17 @@ import Link from 'next/link';
 import SiteLayout from '../../components/SiteLayout';
 import { getCharacters } from '../../lib/content/characters';
 import { getDictionary } from '../../lib/i18n/dictionaries';
-import type { Locale } from '../../lib/i18n/config';
 import { resolveRequestLocale } from '../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../lib/seo';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/characters', 'characters');
 }
 
-export default function CharactersPage() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function CharactersPage() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const characters = getCharacters(locale);
   const basePath = locale === 'hu' ? '/hu' : '';

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,8 +14,8 @@ export const metadata: Metadata = {
   manifest: '/site.webmanifest'
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const locale = resolveRequestLocale();
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const locale = await resolveRequestLocale();
 
   return (
     <html lang={locale} suppressHydrationWarning>

--- a/app/legal/changelog/page.tsx
+++ b/app/legal/changelog/page.tsx
@@ -2,19 +2,18 @@ import type { Metadata } from 'next';
 import SiteLayout from '../../../components/SiteLayout';
 import LegalChangelog from '../../../components/LegalChangelog';
 import { getDictionary } from '../../../lib/i18n/dictionaries';
-import type { Locale } from '../../../lib/i18n/config';
 import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../../lib/seo';
 import { getLegalChangelog } from '../../../lib/legal/content';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/legal/changelog', 'legalChangelog');
 }
 
-export default function LegalChangelogPage() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function LegalChangelogPage() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const changelog = getLegalChangelog(locale);
 

--- a/app/legal/copyright/page.tsx
+++ b/app/legal/copyright/page.tsx
@@ -2,19 +2,18 @@ import type { Metadata } from 'next';
 import SiteLayout from '../../../components/SiteLayout';
 import LegalDocument from '../../../components/LegalDocument';
 import { getDictionary } from '../../../lib/i18n/dictionaries';
-import type { Locale } from '../../../lib/i18n/config';
 import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../../lib/seo';
 import { getLegalDocument } from '../../../lib/legal/content';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/legal/copyright', 'legalCopyright');
 }
 
-export default function CopyrightPage() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function CopyrightPage() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const document = getLegalDocument(locale, 'copyright');
 

--- a/app/legal/fan-content/page.tsx
+++ b/app/legal/fan-content/page.tsx
@@ -2,19 +2,18 @@ import type { Metadata } from 'next';
 import SiteLayout from '../../../components/SiteLayout';
 import LegalDocument from '../../../components/LegalDocument';
 import { getDictionary } from '../../../lib/i18n/dictionaries';
-import type { Locale } from '../../../lib/i18n/config';
 import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../../lib/seo';
 import { getLegalDocument } from '../../../lib/legal/content';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/legal/fan-content', 'legalFanContent');
 }
 
-export default function FanContentPolicyPage() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function FanContentPolicyPage() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const document = getLegalDocument(locale, 'fanContent');
 

--- a/app/legal/trademark/page.tsx
+++ b/app/legal/trademark/page.tsx
@@ -2,19 +2,18 @@ import type { Metadata } from 'next';
 import SiteLayout from '../../../components/SiteLayout';
 import LegalDocument from '../../../components/LegalDocument';
 import { getDictionary } from '../../../lib/i18n/dictionaries';
-import type { Locale } from '../../../lib/i18n/config';
 import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../../lib/seo';
 import { getLegalDocument } from '../../../lib/legal/content';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/legal/trademark', 'legalTrademark');
 }
 
-export default function TrademarkGuidelinesPage() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function TrademarkGuidelinesPage() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const document = getLegalDocument(locale, 'trademark');
 

--- a/app/modes/page.tsx
+++ b/app/modes/page.tsx
@@ -2,12 +2,11 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import SiteLayout from '../../components/SiteLayout';
 import { getDictionary } from '../../lib/i18n/dictionaries';
-import type { Locale } from '../../lib/i18n/config';
 import { resolveRequestLocale } from '../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../lib/seo';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/modes', 'modes', {
     ogImage: 'https://media.aikaworld.com/og-modes.jpg',
@@ -15,8 +14,8 @@ export function generateMetadata(): Metadata {
   });
 }
 
-export default function ModesPage() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function ModesPage() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const sections = dictionary.modes.sections;
   const homeHref = locale === 'hu' ? '/hu' : '/';

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,10 +1,9 @@
 import Link from 'next/link';
 import { getDictionary } from '../lib/i18n/dictionaries';
-import type { Locale } from '../lib/i18n/config';
 import { resolveRequestLocale } from '../lib/i18n/server-locale';
 
-export default function NotFound() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function NotFound() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const homeHref = locale === 'hu' ? '/hu' : '/';
   const charactersHref = locale === 'hu' ? '/hu/characters' : '/characters';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,13 +2,12 @@ import type { Metadata } from 'next';
 import HomePage from '../components/HomePage';
 import SiteLayout from '../components/SiteLayout';
 import { getDictionary } from '../lib/i18n/dictionaries';
-import type { Locale } from '../lib/i18n/config';
 import { serverEnv } from '../lib/server-config';
 import { createStaticPageMetadata } from '../lib/seo';
 import { resolveRequestLocale } from '../lib/i18n/server-locale';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/', 'home', {
     ogImage: 'https://media.aikaworld.com/og-default.png',
@@ -16,8 +15,8 @@ export function generateMetadata(): Metadata {
   });
 }
 
-export default function Page() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function Page() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
 
   return (

--- a/app/presskit/page.tsx
+++ b/app/presskit/page.tsx
@@ -1,19 +1,18 @@
 import type { Metadata } from 'next';
 import SiteLayout from '../../components/SiteLayout';
 import { getDictionary } from '../../lib/i18n/dictionaries';
-import type { Locale } from '../../lib/i18n/config';
 import { resolveRequestLocale } from '../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../lib/seo';
 import { serverEnv } from '../../lib/server-config';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/presskit', 'presskit');
 }
 
-export default function PresskitPage() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function PresskitPage() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const siteUrl = serverEnv.siteUrl.replace(/\/$/, '');
   const organizationJsonLd = {

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -2,19 +2,18 @@ import type { Metadata } from 'next';
 import SiteLayout from '../../components/SiteLayout';
 import LegalDocument from '../../components/LegalDocument';
 import { getDictionary } from '../../lib/i18n/dictionaries';
-import type { Locale } from '../../lib/i18n/config';
 import { resolveRequestLocale } from '../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../lib/seo';
 import { getLegalDocument } from '../../lib/legal/content';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/privacy', 'privacy');
 }
 
-export default function PrivacyPage() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function PrivacyPage() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const document = getLegalDocument(locale, 'privacy');
 

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -2,19 +2,18 @@ import type { Metadata } from 'next';
 import SiteLayout from '../../components/SiteLayout';
 import LegalDocument from '../../components/LegalDocument';
 import { getDictionary } from '../../lib/i18n/dictionaries';
-import type { Locale } from '../../lib/i18n/config';
 import { resolveRequestLocale } from '../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../lib/seo';
 import { getLegalDocument } from '../../lib/legal/content';
 
-export function generateMetadata(): Metadata {
-  const locale = resolveRequestLocale() as Locale;
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/terms', 'terms');
 }
 
-export default function TermsPage() {
-  const locale = resolveRequestLocale() as Locale;
+export default async function TermsPage() {
+  const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const document = getLegalDocument(locale, 'terms');
 

--- a/lib/i18n/server-locale.ts
+++ b/lib/i18n/server-locale.ts
@@ -1,10 +1,11 @@
 import { headers } from 'next/headers';
+import type { Locale } from './config';
 import { defaultLocale, isLocale } from './config';
 
 const HU_PREFIX = '/hu';
 
-export function resolveRequestLocale(): string {
-  const headerList = headers();
+export async function resolveRequestLocale(): Promise<Locale> {
+  const headerList = await headers();
   const headerLocale = headerList.get('x-aika-locale');
 
   if (isLocale(headerLocale)) {


### PR DESCRIPTION
## Summary
- await the Next.js headers API when resolving the request locale and return a typed Locale
- update all pages, metadata generators, and the root layout to wait for the asynchronous locale helper

## Testing
- npm run build *(fails: Next.js attempts to patch SWC dependencies and cannot reach the network, causing ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68dd53b242908325a2cdbc1bf553df45