### PR TITLE
Enable Node compatibility for Cloudflare workers

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,4 @@
 name = "aikaworld-site"
 compatibility_date = "2024-10-01"
 pages_build_output_dir = ".vercel/output/static"
+compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
## Summary
- enable the Cloudflare deployment to run with `nodejs_compat`, ensuring modules such as `node:stream` resolve correctly during publish

## Testing
- npx wrangler pages functions build

------
https://chatgpt.com/codex/tasks/task_e_68dd577b8254832594f0b172ff477d2d