### PR TITLE
Fix Hungarian locale routing

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -53,7 +53,21 @@ export function middleware(request: NextRequest) {
   }
 
   const currentLocale = detectLocaleFromPath(pathname);
-  const response = NextResponse.next();
+
+  const localePrefix = '/hu';
+  const shouldRewriteHu = currentLocale === 'hu';
+
+  const response = shouldRewriteHu
+    ? (() => {
+        const rewriteUrl = request.nextUrl.clone();
+        if (pathname === localePrefix || pathname === `${localePrefix}/`) {
+          rewriteUrl.pathname = '/';
+        } else {
+          rewriteUrl.pathname = pathname.replace(/^\/hu/, '') || '/';
+        }
+        return NextResponse.rewrite(rewriteUrl);
+      })()
+    : NextResponse.next();
   response.headers.set('x-aika-locale', currentLocale);
 
   const cookieLocale = request.cookies.get(LOCALE_COOKIE)?.value;


### PR DESCRIPTION
## Summary
- rewrite Hungarian-prefixed paths in the middleware so localized routes map to existing pages
- continue setting the locale header and cookie to keep dictionary resolution working

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de13a59c488325a9b40db6f6b5df01