### PR TITLE
Update homepage copy with darker tone

### DIFF
--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -42,9 +42,10 @@ export const enDictionary: Dictionary = {
   },
   home: {
     hero: {
-      title: 'Anime co-op action RPG – Raid. Survive. ',
-      highlight: 'Resonance.',
-      description: 'Five Resonators. Towering bosses. Endless waves.',
+      title: 'Dark anime co-op slaughter RPG – Blood. Ruin. ',
+      highlight: 'Sadistic waifus.',
+      description:
+        'Five Resonators. Ruined megastructures. Perpetual slaughter. Blood and screams every round.',
       wishlistCta: 'Wishlist on Steam',
       discordCta: 'Join Discord',
       subscribeCta: 'Subscribe',
@@ -55,14 +56,14 @@ export const enDictionary: Dictionary = {
       cards: [
         {
           title: 'Raid Boss Arena',
-          description: 'Scaling arena fights with colossal bosses. Synergy decides.',
+          description: 'Brutal arenas, merciless bosses. Only synergy keeps you breathing.',
           points: ['Party-size scaling', 'Mechanics and multi-phase fights', 'Team roles'],
           linkLabel: 'View details',
           href: '/modes#raid'
         },
         {
           title: 'Infest Survival',
-          description: 'Endless waves, rising tempo and checkpoint rewards.',
+          description: 'Endless waves, gore and shredded limbs. Only the strongest endure.',
           points: ['Wave-based carnage', 'Checkpoint rewards', 'Meta progression: cosmetics & boosts'],
           linkLabel: 'View details',
           href: '/modes#infest'

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -42,9 +42,10 @@ export const huDictionary: Dictionary = {
   },
   home: {
     hero: {
-      title: 'Anime co-op action RPG – Raid. Survive. ',
-      highlight: 'Resonance.',
-      description: 'Öt Rezonátor. Óriási bossok. Végtelen hullámok.',
+      title: 'Sötét anime co-op hentelős RPG – Vér. Romok. ',
+      highlight: 'Szadista waifuk.',
+      description:
+        'Öt Rezonátor. Összeroskadt világromok. Örökké tartó hentelés. Vér és sikoly minden körben.',
       wishlistCta: 'Wishlist a Steamen',
       discordCta: 'Csatlakozz Discordon',
       subscribeCta: 'Feliratkozom',
@@ -55,14 +56,14 @@ export const huDictionary: Dictionary = {
       cards: [
         {
           title: 'Raid Boss Arena',
-          description: 'Skálázódó aréna-csaták, óriási bossokkal. A szinergia dönt.',
+          description: 'Brutális arénák, könyörtelen bossok. Csak a szinergia tart életben.',
           points: ['Party-size skálázás', 'Mechanikák és fázisok', 'Csapat szerepkörök'],
           linkLabel: 'Részletek megnyitása',
           href: '/hu/modes#raid'
         },
         {
           title: 'Infest Survival',
-          description: 'Végtelen hullámok, fokozódó tempó és checkpoint jutalmak.',
+          description: 'Végtelen hullámok, vér, cafatok, csak a legerősebbek élik túl.',
           points: ['Wave-alapú hentelés', 'Checkpoint jutalmak', 'Meta-progress: kozmetika/boost'],
           linkLabel: 'Részletek megnyitása',
           href: '/hu/modes#infest'


### PR DESCRIPTION
## Summary
- rewrite the homepage hero tagline to emphasize the brutal dark-anime setting in English and Hungarian
- intensify the Game Modes card descriptions for Raid Boss Arena and Infest Survival across both locales

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de205d75108325a6d22c46ba1634b8