### PR TITLE
Fix Hungarian locale routing by removing Next.js i18n config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
-    images: { unoptimized: true },
-    i18n: {
-        locales: ['en', 'hu'],
-        defaultLocale: 'en',
-        localeDetection: false
-    }
+    images: { unoptimized: true }
 };
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- remove the built-in Next.js i18n configuration so that the middleware can rewrite /hu routes and keep locale detection consistent

## Testing
- npm run build *(fails: Cannot find module for page: /_document)*

------
https://chatgpt.com/codex/tasks/task_e_68de2c372ab883259c70d3e19e84a2d2