### PR TITLE
Fix Cloudflare export not-found handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 lib/generated/build-info.ts
 public/android-chrome-192x192.png
 public/android-chrome-512x512.png
+public/apple-touch-icon.png

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,31 +1,8 @@
 export const runtime = 'edge';
+export const dynamic = 'force-static';
 
-import Link from 'next/link';
-import { getDictionary } from '../lib/i18n/dictionaries';
-import { resolveRequestLocale } from '../lib/i18n/server-locale';
+import NotFoundContent from '../components/NotFoundContent';
 
-export default async function NotFound() {
-  const locale = await resolveRequestLocale();
-  const dictionary = getDictionary(locale);
-  const homeHref = locale === 'hu' ? '/hu' : '/';
-  const charactersHref = locale === 'hu' ? '/hu/characters' : '/characters';
-
-  return (
-    <div className="mx-auto max-w-3xl px-4 py-24 text-center">
-      <div className="text-sm uppercase tracking-[0.3em] text-accentB">{dictionary.notFound.code}</div>
-      <h1 className="mt-3 text-3xl md:text-4xl font-bold">{dictionary.notFound.heading}</h1>
-      <p className="mt-4 opacity-80">{dictionary.notFound.description}</p>
-      <div className="mt-8 flex flex-col sm:flex-row justify-center gap-3">
-        <Link href={homeHref} className="rounded-lg border border-white/10 bg-white/5 px-4 py-2 hover:bg-white/10">
-          {dictionary.notFound.homeCta}
-        </Link>
-        <Link
-          href={charactersHref}
-          className="rounded-lg bg-accentB px-4 py-2 font-semibold hover:opacity-90"
-        >
-          {dictionary.notFound.charactersCta}
-        </Link>
-      </div>
-    </div>
-  );
+export default function NotFound() {
+  return <NotFoundContent />;
 }

--- a/components/NotFoundContent.tsx
+++ b/components/NotFoundContent.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import type { Locale } from '../lib/i18n/config';
+import { getDictionary } from '../lib/i18n/dictionaries';
+
+const LOCALE_COOKIE = 'aika_locale';
+const HU_PREFIX = '/hu';
+
+function parseLocaleFromCookie(): Locale | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  const entries = document.cookie.split(';');
+  for (const entry of entries) {
+    const [rawKey, ...rawValue] = entry.trim().split('=');
+    if (!rawKey) {
+      continue;
+    }
+
+    if (rawKey === LOCALE_COOKIE) {
+      const value = decodeURIComponent(rawValue.join('='));
+      if (value === 'hu' || value === 'en') {
+        return value;
+      }
+    }
+  }
+
+  return null;
+}
+
+function detectLocaleFromPath(pathname: string): Locale | null {
+  if (pathname === HU_PREFIX || pathname.startsWith(`${HU_PREFIX}/`)) {
+    return 'hu';
+  }
+
+  return null;
+}
+
+function detectLocaleFromNavigator(): Locale | null {
+  if (typeof navigator === 'undefined') {
+    return null;
+  }
+
+  const candidates = navigator.languages && navigator.languages.length > 0 ? navigator.languages : [navigator.language];
+
+  for (const lang of candidates) {
+    if (!lang) {
+      continue;
+    }
+
+    const base = lang.toLowerCase().split('-')[0];
+    if (base === 'hu') {
+      return 'hu';
+    }
+    if (base === 'en') {
+      return 'en';
+    }
+  }
+
+  return null;
+}
+
+function detectLocale(): Locale {
+  const cookieLocale = parseLocaleFromCookie();
+  if (cookieLocale) {
+    return cookieLocale;
+  }
+
+  if (typeof window !== 'undefined') {
+    const pathLocale = detectLocaleFromPath(window.location.pathname);
+    if (pathLocale) {
+      return pathLocale;
+    }
+  }
+
+  const navigatorLocale = detectLocaleFromNavigator();
+  if (navigatorLocale) {
+    return navigatorLocale;
+  }
+
+  return 'en';
+}
+
+export default function NotFoundContent() {
+  const [locale, setLocale] = useState<Locale>('en');
+
+  useEffect(() => {
+    setLocale(detectLocale());
+  }, []);
+
+  const dictionary = getDictionary(locale);
+  const homeHref = locale === 'hu' ? '/hu' : '/';
+  const charactersHref = locale === 'hu' ? '/hu/characters' : '/characters';
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-24 text-center">
+      <div className="text-sm uppercase tracking-[0.3em] text-accentB">{dictionary.notFound.code}</div>
+      <h1 className="mt-3 text-3xl md:text-4xl font-bold">{dictionary.notFound.heading}</h1>
+      <p className="mt-4 opacity-80">{dictionary.notFound.description}</p>
+      <div className="mt-8 flex flex-col sm:flex-row justify-center gap-3">
+        <Link href={homeHref} className="rounded-lg border border-white/10 bg-white/5 px-4 py-2 hover:bg-white/10">
+          {dictionary.notFound.homeCta}
+        </Link>
+        <Link href={charactersHref} className="rounded-lg bg-accentB px-4 py-2 font-semibold hover:opacity-90">
+          {dictionary.notFound.charactersCta}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "build": "npm run generate:static-icons && npm run validate:translations && npm run generate:build-info && next build",
         "postbuild": "node ./scripts/wayback-save.mjs",
         "start": "next start",
-        "export:cf": "npx @cloudflare/next-on-pages@1"
+        "export:cf": "npx vercel build && node ./scripts/patch-vercel-output.mjs && npx @cloudflare/next-on-pages@1 --skip-build"
     },
     "dependencies": {
         "next": "^15.0.0",

--- a/scripts/patch-vercel-output.mjs
+++ b/scripts/patch-vercel-output.mjs
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const outputDir = path.resolve('.vercel/output');
+const configPath = path.join(outputDir, 'config.json');
+const functionsDir = path.join(outputDir, 'functions');
+
+if (!fs.existsSync(configPath)) {
+  console.error('[patch-vercel-output] Skipping: config.json not found.');
+  process.exit(0);
+}
+
+const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+let updatedRoute = false;
+
+if (Array.isArray(config.routes)) {
+  for (const route of config.routes) {
+    if (route && route.dest === '/_not-found') {
+      route.dest = '/404';
+      updatedRoute = true;
+    }
+  }
+}
+
+if (!updatedRoute) {
+  console.warn('[patch-vercel-output] Warning: no /_not-found route found to patch.');
+} else {
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+}
+
+const functionDirsToRemove = ['_not-found.func', '_not-found.rsc.func'];
+for (const dirName of functionDirsToRemove) {
+  const fullPath = path.join(functionsDir, dirName);
+  if (fs.existsSync(fullPath)) {
+    fs.rmSync(fullPath, { recursive: true, force: true });
+  }
+}
+
+console.log('[patch-vercel-output] Patched Vercel build output for not-found route.');


### PR DESCRIPTION
## Summary
- add a client-side not-found view that avoids relying on request headers
- patch the Vercel build output to serve the static 404 page instead of the node runtime function
- update the Cloudflare export script to build, patch, and reuse the prepared output

## Testing
- npm run export:cf

------
https://chatgpt.com/codex/tasks/task_e_68de361cb474832590e3577882c23e31