### PR TITLE
Cloudflare analytics token kezelése

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ The `out` directory contains the artefacts that should be deployed. You can chai
 | Build command           | `npm run build && npx next export`      |
 | Build output directory  | `out`                                   |
 | Node.js version         | `18`                                    |
-| Environment variables   | `WAYBACK_SAVE_ON_DEPLOY` (optional)     |
+| Environment variables   | `CF_ANALYTICS_TOKEN` (kötelező), `WAYBACK_SAVE_ON_DEPLOY` (opcionális) |
 
 Ensure the build step runs the exact command pair above when setting up your own CI pipeline.
+
+A Cloudflare Insights beacon csak akkor töltődik be, ha a `CF_ANALYTICS_TOKEN` környezeti változó meg van adva; ennek a tokennek a beállítása kötelező az éles telepítéshez.
 
 ## Internationalisation (i18n)
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ export const runtime = 'edge';
 import './globals.css';
 import type { Metadata } from 'next';
 import { resolveRequestLocale } from '../lib/i18n/server-locale';
+import { serverEnv } from '../lib/server-config';
 
 export const metadata: Metadata = {
   icons: {
@@ -22,11 +23,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang={locale} suppressHydrationWarning>
       <head>
-        <script
-          defer
-          src="https://static.cloudflareinsights.com/beacon.min.js"
-          data-cf-beacon='{"token": "ENV_CF_ANALYTICS_TOKEN"}'
-        />
+        {serverEnv.cfAnalyticsToken && (
+          <script
+            defer
+            src="https://static.cloudflareinsights.com/beacon.min.js"
+            data-cf-beacon={JSON.stringify({ token: serverEnv.cfAnalyticsToken })}
+          />
+        )}
       </head>
       <body className="min-h-dvh antialiased bg-[#05060a] text-white">
         {children}

--- a/lib/server-config.ts
+++ b/lib/server-config.ts
@@ -1,4 +1,4 @@
-const optionalEnv = ['STEAM_URL', 'DISCORD_URL'] as const;
+const optionalEnv = ['STEAM_URL', 'DISCORD_URL', 'CF_ANALYTICS_TOKEN'] as const;
 
 function readOptionalEnv(name: (typeof optionalEnv)[number]) {
   const value = process.env[name];
@@ -39,7 +39,8 @@ function resolveSiteUrl() {
 export const serverEnv = {
   steamUrl: readOptionalEnv('STEAM_URL'),
   discordUrl: readOptionalEnv('DISCORD_URL'),
-  siteUrl: resolveSiteUrl()
+  siteUrl: resolveSiteUrl(),
+  cfAnalyticsToken: readOptionalEnv('CF_ANALYTICS_TOKEN')
 } as const;
 
 export type ServerEnv = typeof serverEnv;


### PR DESCRIPTION
## Összefoglaló
- opcionális Cloudflare Analytics token beolvasása a szerveroldali konfigurációban
- a layout csak akkor tölti be a Cloudflare beacon szkriptet, ha elérhető a token és dinamikusan tölti ki az értéket
- dokumentáció frissítése a CF_ANALYTICS_TOKEN kötelező környezeti változóval

## Tesztelés
- nem futtattam automatizált teszteket (konfigurációs módosítások)

------
https://chatgpt.com/codex/tasks/task_e_68de4c8e57908325b6d1c1af097733de