### PR TITLE
Improve lightbox focus trapping and accessibility

### DIFF
--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import type { LightboxDictionary } from '../lib/i18n/types';
 
 type LightboxImage = {
@@ -27,6 +27,15 @@ const clampIndex = (index: number, length: number) => {
 export default function Lightbox({ images, isOpen, initialIndex = 0, onClose, dictionary }: LightboxProps) {
   const sanitizedInitialIndex = useMemo(() => clampIndex(initialIndex, images.length), [initialIndex, images.length]);
   const [currentIndex, setCurrentIndex] = useState(sanitizedInitialIndex);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const prevButtonRef = useRef<HTMLButtonElement | null>(null);
+  const nextButtonRef = useRef<HTMLButtonElement | null>(null);
+  const firstFocusableRef = useRef<HTMLElement | null>(null);
+  const lastFocusableRef = useRef<HTMLElement | null>(null);
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
+  const descriptionId = useId();
 
   useEffect(() => {
     if (isOpen) {
@@ -53,12 +62,44 @@ export default function Lightbox({ images, isOpen, initialIndex = 0, onClose, di
       if (event.key === 'Escape') {
         event.preventDefault();
         onClose();
-      } else if (event.key === 'ArrowRight') {
+        return;
+      }
+
+      if (event.key === 'ArrowRight') {
         event.preventDefault();
         showNext();
-      } else if (event.key === 'ArrowLeft') {
+        return;
+      }
+
+      if (event.key === 'ArrowLeft') {
         event.preventDefault();
         showPrev();
+        return;
+      }
+
+      if (event.key === 'Tab') {
+        const container = containerRef.current;
+        const firstFocusable = firstFocusableRef.current;
+        const lastFocusable = lastFocusableRef.current ?? firstFocusable;
+
+        if (!container || !firstFocusable || !lastFocusable) {
+          return;
+        }
+
+        const isFocusWithinDialog = container.contains(document.activeElement);
+
+        if (event.shiftKey) {
+          if (!isFocusWithinDialog || document.activeElement === firstFocusable) {
+            event.preventDefault();
+            lastFocusable.focus();
+          }
+          return;
+        }
+
+        if (!isFocusWithinDialog || document.activeElement === lastFocusable) {
+          event.preventDefault();
+          firstFocusable.focus();
+        }
       }
     };
 
@@ -82,6 +123,44 @@ export default function Lightbox({ images, isOpen, initialIndex = 0, onClose, di
     };
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    previouslyFocusedElementRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const focusableElements = [
+      closeButtonRef.current,
+      prevButtonRef.current,
+      nextButtonRef.current,
+    ].filter((element): element is HTMLElement => element !== null);
+
+    firstFocusableRef.current = focusableElements[0] ?? null;
+    lastFocusableRef.current = focusableElements[focusableElements.length - 1] ?? firstFocusableRef.current;
+
+    const focusTarget = firstFocusableRef.current ?? containerRef.current;
+
+    if (focusTarget) {
+      requestAnimationFrame(() => {
+        focusTarget.focus();
+      });
+    }
+
+    return () => {
+      const previouslyFocusedElement = previouslyFocusedElementRef.current;
+      firstFocusableRef.current = null;
+      lastFocusableRef.current = null;
+      previouslyFocusedElementRef.current = null;
+
+      if (previouslyFocusedElement) {
+        requestAnimationFrame(() => {
+          previouslyFocusedElement.focus();
+        });
+      }
+    };
+  }, [isOpen]);
+
   if (!isOpen || images.length === 0) {
     return null;
   }
@@ -91,19 +170,28 @@ export default function Lightbox({ images, isOpen, initialIndex = 0, onClose, di
 
   return (
     <div
+      ref={containerRef}
       className="fixed inset-0 z-50 flex flex-col bg-black/90 backdrop-blur"
       role="dialog"
       aria-modal
-      aria-label={dictionary.ariaLabel}
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      tabIndex={-1}
       onClick={onClose}
     >
       <div className="flex items-center justify-between gap-4 p-4 text-white">
-        <span className="text-sm md:text-base opacity-80">
-          {currentIndex + 1} / {totalImages}
-        </span>
+        <div className="flex flex-col gap-1">
+          <h2 id={titleId} className="text-base font-semibold md:text-lg">
+            {dictionary.ariaLabel}
+          </h2>
+          <span id={descriptionId} className="text-sm opacity-80 md:text-base">
+            {currentIndex + 1} / {totalImages}
+          </span>
+        </div>
         <button
           type="button"
           onClick={onClose}
+          ref={closeButtonRef}
           className="rounded-full border border-white/20 px-4 py-2 text-sm font-medium hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
           aria-label={dictionary.close}
         >
@@ -115,6 +203,7 @@ export default function Lightbox({ images, isOpen, initialIndex = 0, onClose, di
         <button
           type="button"
           onClick={showPrev}
+          ref={prevButtonRef}
           className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full border border-white/20 bg-black/40 px-4 py-2 text-white hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
           aria-label={dictionary.previous}
         >
@@ -133,6 +222,7 @@ export default function Lightbox({ images, isOpen, initialIndex = 0, onClose, di
         <button
           type="button"
           onClick={showNext}
+          ref={nextButtonRef}
           className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full border border-white/20 bg-black/40 px-4 py-2 text-white hover:bg-black/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
           aria-label={dictionary.next}
         >


### PR DESCRIPTION
## Summary
- add refs for the lightbox controls to manage focus programmatically
- trap focus within the dialog and restore the previously focused element on close
- expose a heading and description via aria-labelledby/aria-describedby for better screen reader context

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68de4d6336108325ac345ba12d082109