### PR TITLE
Add localized hero image alt text for characters

### DIFF
--- a/app/characters/[slug]/page.tsx
+++ b/app/characters/[slug]/page.tsx
@@ -50,7 +50,7 @@ export default async function CharacterPage({ params }: CharacterPageProps) {
         <div className="absolute inset-0 -z-10">
           <img
             src={character.heroImage}
-            alt={`${character.name} hero banner`}
+            alt={character.heroImageAlt}
             className="h-full w-full object-cover"
             loading="lazy"
           />

--- a/app/characters/page.tsx
+++ b/app/characters/page.tsx
@@ -44,7 +44,7 @@ export default async function CharactersPage() {
               <div className="aspect-[16/9] w-full overflow-hidden">
                 <img
                   src={character.heroImage}
-                  alt={`${character.name} hero art`}
+                  alt={character.heroImageAlt}
                   className="h-full w-full object-cover"
                   loading="lazy"
                 />

--- a/components/Lightbox.tsx
+++ b/components/Lightbox.tsx
@@ -134,7 +134,7 @@ export default function Lightbox({ images, isOpen, initialIndex = 0, onClose, di
       closeButtonRef.current,
       prevButtonRef.current,
       nextButtonRef.current,
-    ].filter((element): element is HTMLElement => element !== null);
+    ].filter((element): element is HTMLButtonElement => element !== null);
 
     firstFocusableRef.current = focusableElements[0] ?? null;
     lastFocusableRef.current = focusableElements[focusableElements.length - 1] ?? firstFocusableRef.current;

--- a/lib/content/characters.ts
+++ b/lib/content/characters.ts
@@ -8,6 +8,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Akari',
       title: 'Blazeblade Vanguard',
       heroImage: 'https://media.aikaworld.com/akari-banner.png',
+      heroImageAlt: 'Akari charges forward with a blazing greatsword amid flying sparks.',
       role: 'Frontline DPS',
       element: 'Fire',
       playstyle:
@@ -30,6 +31,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Komi',
       title: 'Tideweaver Oracle',
       heroImage: 'https://media.aikaworld.com/komi-banner.png',
+      heroImageAlt: 'Komi stands calm as ribbons of water swirl around her hands.',
       role: 'Support control',
       element: 'Water',
       playstyle:
@@ -52,6 +54,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Yui',
       title: 'Gale Dancer',
       heroImage: 'https://media.aikaworld.com/yui-banner.png',
+      heroImageAlt: 'Yui flips through a neon skyline with twin daggers drawn mid-air.',
       role: 'Mobility DPS',
       element: 'Wind',
       playstyle:
@@ -73,6 +76,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Hina',
       title: 'Edge Serenade',
       heroImage: 'https://media.aikaworld.com/hina-banner.png',
+      heroImageAlt: 'Hina holds her violin blade poised as crimson petals drift around.',
       role: 'Assassin burst',
       element: 'Blade',
       playstyle:
@@ -94,6 +98,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Miyu',
       title: 'Luminous Aegis',
       heroImage: 'https://media.aikaworld.com/miyu-banner.png',
+      heroImageAlt: 'Miyu raises a radiant shield while luminous vines spiral from her arm.',
       role: 'Shield-focused healer',
       element: 'Light',
       playstyle:
@@ -117,6 +122,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Akari',
       title: 'Blazeblade Vanguard',
       heroImage: 'https://media.aikaworld.com/akari-banner.png',
+      heroImageAlt: 'Akari lángoló karddal rohan előre, körülötte szikrák villannak.',
       role: 'Frontvonal DPS',
       element: 'Tűz',
       playstyle:
@@ -141,6 +147,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Komi',
       title: 'Tideweaver Oracle',
       heroImage: 'https://media.aikaworld.com/komi-banner.png',
+      heroImageAlt: 'Komi mozdulatlan nyugalommal áll, miközben vízszalagok örvénylenek a kezei körül.',
       role: 'Támogató kontroll',
       element: 'Víz',
       playstyle:
@@ -165,6 +172,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Yui',
       title: 'Gale Dancer',
       heroImage: 'https://media.aikaworld.com/yui-banner.png',
+      heroImageAlt: 'Yui két pengével pörög a neonfényes ég alatt, a levegőben lebegve.',
       role: 'Mobility DPS',
       element: 'Szél',
       playstyle:
@@ -189,6 +197,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Hina',
       title: 'Edge Serenade',
       heroImage: 'https://media.aikaworld.com/hina-banner.png',
+      heroImageAlt: 'Hina felemelt hegedűpengével áll, miközben bíborszirmok lebegnek körülötte.',
       role: 'Assassin Burst',
       element: 'Penge',
       playstyle:
@@ -213,6 +222,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       name: 'Miyu',
       title: 'Luminous Aegis',
       heroImage: 'https://media.aikaworld.com/miyu-banner.png',
+      heroImageAlt: 'Miyu fénylő pajzsot emel, és ragyogó indák tekerednek a karjáról.',
       role: 'Gyógyító pajzsfókusz',
       element: 'Fény',
       playstyle:

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -123,6 +123,7 @@ export type Character = {
   name: string;
   title: string;
   heroImage: string;
+  heroImageAlt: string;
   role: string;
   element: string;
   playstyle: string;


### PR DESCRIPTION
## Summary
- add a heroImageAlt field to the character type and populate localized values for each character in English and Hungarian content
- render the localized alt text on the character listing and detail pages
- adjust the lightbox focus trap predicate to satisfy TypeScript after the stricter character typing change

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de556993188325b06d27ce9c623e73