### PR TITLE
feat: extend header navigation for modes and presskit pages

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -61,6 +61,36 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
     [dictionary.locales]
   );
 
+  const navItems = useMemo(
+    () =>
+      [
+        dictionary.nav.modes,
+        dictionary.nav.modesPage,
+        dictionary.nav.characters,
+        dictionary.nav.media,
+        dictionary.nav.roadmap,
+        dictionary.nav.community,
+        dictionary.nav.presskit
+      ],
+    [dictionary.nav]
+  );
+
+  const resolveHref = (href: string) => {
+    if (href.startsWith('#')) {
+      return `${basePath}${href}`;
+    }
+
+    if (href.startsWith('http://') || href.startsWith('https://')) {
+      return href;
+    }
+
+    if (basePath && href.startsWith(basePath)) {
+      return href;
+    }
+
+    return `${basePath}${href}`;
+  };
+
   return (
     <header
       className={`fixed inset-x-0 top-0 z-50 border-b border-white/10 backdrop-blur transition-colors ${
@@ -72,21 +102,11 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
           {dictionary.brand}
         </a>
         <nav className="hidden items-center gap-4 text-sm md:flex" aria-label={dictionary.navLabel}>
-          <a href={`${basePath}#modes`} className="hover:opacity-80">
-            {dictionary.nav.modes}
-          </a>
-          <a href={`${basePath}/characters`} className="hover:opacity-80">
-            {dictionary.nav.characters}
-          </a>
-          <a href={`${basePath}#media`} className="hover:opacity-80">
-            {dictionary.nav.media}
-          </a>
-          <a href={`${basePath}#roadmap`} className="hover:opacity-80">
-            {dictionary.nav.roadmap}
-          </a>
-          <a href={`${basePath}#community`} className="hover:opacity-80">
-            {dictionary.nav.community}
-          </a>
+          {navItems.map(item => (
+            <a key={item.label} href={resolveHref(item.href)} className="hover:opacity-80">
+              {item.label}
+            </a>
+          ))}
         </nav>
         <div className="flex items-center gap-2">
           <label className="sr-only" htmlFor="locale-switcher">

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -7,11 +7,13 @@ export const enDictionary: Dictionary = {
     brand: 'AIKA WORLD',
     navLabel: 'Primary navigation',
     nav: {
-      modes: 'Modes',
-      characters: 'Characters',
-      media: 'Media',
-      roadmap: 'Roadmap',
-      community: 'Community'
+      modes: { label: 'Modes', href: '#modes' },
+      characters: { label: 'Characters', href: '/characters' },
+      media: { label: 'Media', href: '#media' },
+      roadmap: { label: 'Roadmap', href: '#roadmap' },
+      community: { label: 'Community', href: '#community' },
+      modesPage: { label: 'Detailed game modes', href: '/modes' },
+      presskit: { label: 'Presskit', href: '/presskit' }
     },
     wishlistCta: 'Wishlist on Steam',
     discordCta: 'Join Discord',

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -7,11 +7,13 @@ export const huDictionary: Dictionary = {
     brand: 'AIKA WORLD',
     navLabel: 'Fő navigáció',
     nav: {
-      modes: 'Játékmódok',
-      characters: 'Karakterek',
-      media: 'Média',
-      roadmap: 'Roadmap',
-      community: 'Közösség'
+      modes: { label: 'Játékmódok', href: '#modes' },
+      characters: { label: 'Karakterek', href: '/characters' },
+      media: { label: 'Média', href: '#media' },
+      roadmap: { label: 'Roadmap', href: '#roadmap' },
+      community: { label: 'Közösség', href: '#community' },
+      modesPage: { label: 'Részletes játékmódok', href: '/hu/modes' },
+      presskit: { label: 'Presskit', href: '/hu/presskit' }
     },
     wishlistCta: 'Wishlist a Steamen',
     discordCta: 'Csatlakozz Discordon',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -196,15 +196,22 @@ export type NotFoundDictionary = {
   charactersCta: string;
 };
 
+export type HeaderNavItem = {
+  label: string;
+  href: string;
+};
+
 export type HeaderDictionary = {
   brand: string;
   navLabel: string;
   nav: {
-    modes: string;
-    characters: string;
-    media: string;
-    roadmap: string;
-    community: string;
+    modes: HeaderNavItem;
+    characters: HeaderNavItem;
+    media: HeaderNavItem;
+    roadmap: HeaderNavItem;
+    community: HeaderNavItem;
+    modesPage: HeaderNavItem;
+    presskit: HeaderNavItem;
   };
   wishlistCta: string;
   discordCta: string;


### PR DESCRIPTION
## Summary
- add structured header navigation entries so links include labels and destinations
- localize the new detailed modes and presskit links in the English and Hungarian dictionaries
- render the extended navigation set in the header with locale-aware href handling

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de68e4471083259694ea48815b0da8