### PR TITLE
World & Factions teaser a főoldalra

### DIFF
--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -145,6 +145,34 @@ export default function HomePage({
         </div>
       </section>
 
+      {/* WORLD & FACTIONS */}
+      <section id="world" className="mx-auto max-w-6xl px-4 py-16">
+        <h2 className="text-2xl md:text-3xl font-bold">{dictionary.world.title}</h2>
+        <p className="mt-3 opacity-90 max-w-3xl">{dictionary.world.intro}</p>
+        <div className="mt-8 grid gap-6 md:grid-cols-3">
+          {dictionary.world.factions.map(faction => (
+            <div
+              key={faction.name}
+              className="rounded-2xl border border-white/10 bg-white/5 p-6 flex flex-col"
+            >
+              <div>
+                <h3 className="text-xl font-semibold">{faction.name}</h3>
+                <p className="mt-2 text-sm font-semibold text-accentB">{faction.tagline}</p>
+              </div>
+              <ul className="mt-4 list-disc list-inside text-sm opacity-80 space-y-2">
+                {faction.bullets.map(bullet => (
+                  <li key={bullet}>{bullet}</li>
+                ))}
+              </ul>
+              <div className="mt-auto pt-6 flex items-center gap-2 text-sm font-semibold text-accentB">
+                <span>Learn more</span>
+                <span aria-hidden>→</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
       {/* MODES */}
       <section id="modes" className="mx-auto max-w-6xl px-4 py-16">
         <h2 className="text-2xl md:text-3xl font-bold">{dictionary.modes.title}</h2>

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -53,6 +53,58 @@ export const enDictionary: Dictionary = {
       subscribeCta: 'Subscribe',
       videoPosterAlt: 'AIKA World teaser poster'
     },
+    world: {
+      title: 'World & Factions',
+      intro:
+        'Five rival power blocs shape the neon dusk of AIKA World. Align with the ideology that keeps your squad alive.',
+      factions: [
+        {
+          name: 'Emberforge Combine',
+          tagline: 'Industrial firebrands who temper the city in magma-fed forges.',
+          bullets: [
+            'Fire-reactor foundries forge modular weaponry overnight.',
+            'Logistics guilds keep squads stocked with incendiary ordnance.',
+            'Engineers retrofit armor with heat-reactive plating.'
+          ]
+        },
+        {
+          name: 'Verdant Circuit Assembly',
+          tagline: 'Druidatech innovators weaving nature-grown circuitry with ritual.',
+          bullets: [
+            'Biofiber drones scout rooftops while pollinating safe zones.',
+            'Healing greenhouses double as respawn sanctuaries for squads.',
+            'Councils broker truces through data-bloom ceremonies.'
+          ]
+        },
+        {
+          name: 'Abyssal Veil Court',
+          tagline: 'Waterborne aristocracy ruling through shadowed etiquette.',
+          bullets: [
+            'Courtiers trade secrets via tide-locked encrypted mirrors.',
+            'Shadow entourages escort squads through submerged backstreets.',
+            'Oaths signed in abyssal ink carry lethal enforcement.'
+          ]
+        },
+        {
+          name: 'Silver Vow Order',
+          tagline: 'Knightly guardians wielding relic lances and luminous shields.',
+          bullets: [
+            'Paladin companies drill cooperative formations for raids.',
+            'Shield-chaplains sanctify gear against corruption pulses.',
+            'Pilgrimage supply lines secure safe corridors between hubs.'
+          ]
+        },
+        {
+          name: 'Neon Veil Collective',
+          tagline: 'Cyberpunk underground thriving in glitch-lit tunnels.',
+          bullets: [
+            'Signal jammers mask squads from corporate trackers.',
+            'Cybernetic medics patch wounds with improvised firmware.',
+            'Street alliances unlock black market upgrades between runs.'
+          ]
+        }
+      ]
+    },
     modes: {
       title: 'Game Modes',
       cards: [
@@ -320,7 +372,7 @@ export const enDictionary: Dictionary = {
     pages: {
       home: {
         title: 'AIKA World – Anime co-op action RPG',
-        description: 'Co-op raid arenas, dark anime visuals and deep progression systems with five unique Resonators.',
+        description: 'Co-op raid arenas, dark fantasy factions and deep progression systems with five unique Resonators.',
         ogAlt: 'AIKA World hero artwork'
       },
       modes: {

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -53,6 +53,58 @@ export const huDictionary: Dictionary = {
       subscribeCta: 'Feliratkozom',
       videoPosterAlt: 'AIKA World teaser poszter'
     },
+    world: {
+      title: 'Világ és frakciók',
+      intro:
+        'Öt rivális hatalmi tömb uralja az AIKA World neon-alkonyát. Állj arra, amelyik életben tartja a csapatod.',
+      factions: [
+        {
+          name: 'Emberforge Combine',
+          tagline: 'Ipari lángharcosok, akik magma-táplált kohókban edzik a várost.',
+          bullets: [
+            'Tűzreaktoros kohók egy éjszaka alatt moduláris fegyvereket öntenek.',
+            'Logisztikai céhek gondoskodnak az égő lőszerek folyamatos utánpótlásáról.',
+            'Mérnökeik hőre reagáló páncélrétegekkel szerelik fel a csapatokat.'
+          ]
+        },
+        {
+          name: 'Verdant Circuit Assembly',
+          tagline: 'Druidatech újítók, akik természetben nőtt áramköröket fonnak rítusokkal.',
+          bullets: [
+            'Biofibrás drónjaik felderítik a tetőket és közben biztonságos zónákat poroznak be.',
+            'Gyógyító üvegházaik egyben respawn menedékek a csapatnak.',
+            'Tanácsaik adat-virágzás ceremóniákon közvetítenek fegyverszünetet.'
+          ]
+        },
+        {
+          name: 'Abyssal Veil Court',
+          tagline: 'Vízre épült arisztokrácia, akik árnyékos etikettel uralkodnak.',
+          bullets: [
+            'Udvaroncok dagályra hangolt titkos tükrökön cserélik a bizalmas információkat.',
+            'Árnyékkíséreteik elárasztott sikátorokon vezetik át a csapatokat.',
+            'A mélységi tintával írt eskük halálos következményekkel járnak.'
+          ]
+        },
+        {
+          name: 'Silver Vow Order',
+          tagline: 'Lovagi őrség, relikvia-lándzsákkal és fénylő pajzsokkal.',
+          bullets: [
+            'Paladin szakaszaik kooperatív formációkat gyakorolnak a raidhez.',
+            'Pajzskaplánjaik megszentelik a felszerelést a korrupciós hullámok ellen.',
+            'Zarándok szállítmányaik biztonságos folyosókat nyitnak a hubok között.'
+          ]
+        },
+        {
+          name: 'Neon Veil Collective',
+          tagline: 'Cyberpunk földalatti hálózat, glitch-fényű alagutakban.',
+          bullets: [
+            'Jelzészavaróik elrejtik a csapatot a vállalati követők elől.',
+            'Kiborg medikusok rögtönzött firmware-rel foltozzák be a sebeket.',
+            'Utcai szövetségeik fekete piaci fejlesztéseket oldanak fel a menetek között.'
+          ]
+        }
+      ]
+    },
     modes: {
       title: 'Játékmódok',
       cards: [
@@ -321,7 +373,7 @@ export const huDictionary: Dictionary = {
     pages: {
       home: {
         title: 'AIKA World – Anime co-op action RPG',
-        description: 'Kooperatív raid arénák, sötét anime látvány és mély fejlődési rendszerek öt egyedi Rezonátorral.',
+        description: 'Co-op raid arénák, sötét fantasy frakciók és mély fejlődési rendszerek öt egyedi Rezonátorral.',
         ogAlt: 'AIKA World hős grafika'
       },
       modes: {

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -33,6 +33,15 @@ export type HomeDictionary = {
     subscribeCta: string;
     videoPosterAlt: string;
   };
+  world: {
+    title: string;
+    intro: string;
+    factions: {
+      name: string;
+      tagline: string;
+      bullets: string[];
+    }[];
+  };
   modes: {
     title: string;
     cards: {


### PR DESCRIPTION
## Összefoglaló
- "World & Factions" blokkot adtam a főoldalhoz, reszponzív rácselrendezéssel és angol UI címkékkel.
- Két nyelven rögzítettem a frakciók teaser tartalmát, valamint frissítettem a home SEO leírást a dark fantasy / factions / co-op kulcsszavakkal.
- Kibővítettem a `HomeDictionary` típust az új world struktúrával.

## Tesztelés
- `npm run validate:translations`


------
https://chatgpt.com/codex/tasks/task_e_68de6fa9157c8325836fc41abcd26a1b