### PR TITLE
Update home mode cards content

### DIFF
--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -110,29 +110,39 @@ export const enDictionary: Dictionary = {
       cards: [
         {
           title: 'Raid Boss Arena',
-          description: 'Brutal arenas, merciless bosses. Only synergy keeps you breathing.',
-          points: ['Party-size scaling', 'Mechanics and multi-phase fights', 'Team roles'],
-          linkLabel: 'View details',
-          href: '/modes#raid'
+          description:
+            "Drop into a five-player co-op boss gauntlet where every arena reveals layered mechanics without spoiling the finale. Master tells, stagger windows, and arena hazards to carve openings for your Resonators. Coordinated cooldowns and revives decide whether the squad extracts rare materials or wipes.",
+          points: [
+            'Five-player co-op boss encounters',
+            'Layered mechanics without spoilers',
+            'Shared loot and mastery rewards'
+          ],
+          linkLabel: 'See details',
+          href: '#'
         },
         {
           title: 'Infest Survival',
-          description: 'Endless waves, gore and shredded limbs. Only the strongest endure.',
-          points: ['Wave-based carnage', 'Checkpoint rewards', 'Meta progression: cosmetics & boosts'],
-          linkLabel: 'View details',
-          href: '/modes#infest'
+          description:
+            'Hold choke points against endless waves that escalate with corrupt variants while keeping momentum spoiler-free. Every cleared milestone unlocks checkpoint rewards—temporary buffs, crafting drops, or extraction intel—before the swarm resets. Rotate roles, bank resources, and decide when to push deeper or secure the run.',
+          points: [
+            'Endless wave escalation',
+            'Checkpoint rewards to bank',
+            'Risk-versus-reward extractions'
+          ],
+          linkLabel: 'See details',
+          href: '#'
         },
         {
-          title: 'Story Mode',
+          title: 'Open World Expedition',
           description:
-            'Character-driven episodes, choice-based dialogue and slice-of-life downtime with your squad.',
+            "Scout the overworld at your squad's pace, uncovering biomes, hubs, and lore breadcrumbs without revealing twists. Parkour routes, traversal gadgets, and dynamic weather alter every expedition. Track world events, unlock shortcuts, and gather intel that fuels raids and infest runs while staying spoiler-safe.",
           points: [
-            'Episodic missions with new hub locations',
-            'Reputation branches and multiple endings',
-            'Co-op social decisions and light roleplay'
+            'Exploration-first pacing',
+            'Traversal tools and weather shifts',
+            'Intel that feeds raids and infest'
           ],
-          linkLabel: 'View details',
-          href: '/modes#story'
+          linkLabel: 'See details',
+          href: '#'
         }
       ]
     },

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -110,29 +110,39 @@ export const huDictionary: Dictionary = {
       cards: [
         {
           title: 'Raid Boss Arena',
-          description: 'Brutális arénák, könyörtelen bossok. Csak a szinergia tart életben.',
-          points: ['Party-size skálázás', 'Mechanikák és fázisok', 'Csapat szerepkörök'],
-          linkLabel: 'Részletek megnyitása',
-          href: '/hu/modes#raid'
+          description:
+            'Öt fős kooperatív boss aréna, ahol a pályák rétegről rétegre tárják fel a mechanikákat, spoilerek nélkül. Olvasd a teleket, kezeld a fázisváltásokat, és védd a csapatot a csapdáktól. A koordinált ultik, élesztések és pozíciócserék döntik el, hogy zsákmányolsz vagy wipe-olsz.',
+          points: [
+            'Öt fős co-op boss összecsapások',
+            'Rétegezett mechanikák spoiler nélkül',
+            'Megosztott loot és fejlődési jutalmak'
+          ],
+          linkLabel: 'See details',
+          href: '#'
         },
         {
           title: 'Infest Survival',
-          description: 'Végtelen hullámok, vér, cafatok, csak a legerősebbek élik túl.',
-          points: ['Wave-alapú hentelés', 'Checkpoint jutalmak', 'Meta-progress: kozmetika/boost'],
-          linkLabel: 'Részletek megnyitása',
-          href: '/hu/modes#infest'
+          description:
+            'Végtelen hullámok ellen tartod a frontot, miközben a korcs variánsok egyre keményebben tesztelik a túlélési rutinokat, spoiler nélkül. Minden elért mérföldkő checkpoint jutalmakat ad – ideiglenes buffok, craft loot vagy taktikák –, mielőtt az újabb raj eláraszt. Rotáld a szerepeket, menedzseld az erőforrásokat.',
+          points: [
+            'Végtelen hullám skálázódás',
+            'Checkpoint jutalmak bankolása',
+            'Kockázat vs. jutalom extrakció'
+          ],
+          linkLabel: 'See details',
+          href: '#'
         },
         {
-          title: 'Story Mode',
+          title: 'Nyílt Világ Expedíció',
           description:
-            'Karakterközpontú epizódok, döntés alapú dialógusok és slice-of-life pillanatok a csapat mindennapjaiból.',
+            'Fesztiválfényű nyílt világot jársz be a saját tempódban, felfedve biomeszegmenseket, hubokat és lore-morzsákat anélkül, hogy a nagy fordulatokat lelőnénk. Parkour útvonalak, mozgásfokozó eszközök és dinamikus időjárás alakítják az expedíciót. Kövesd az eseményeket, nyisd a rövidítéseket, gyűjts felderítési intelt a raidhez és infesthez.',
           points: [
-            'Epizodikus küldetések új hub-helyszínekkel',
-            'Reputáció ágak és több befejezés',
-            'Közösségi kooperációs döntések és szerepjáték'
+            'Felfedezésközpontú tempó',
+            'Haladó mozgás és időjárás',
+            'Intel, ami a raidhez és infesthez táplál'
           ],
-          linkLabel: 'Részletek megnyitása',
-          href: '/hu/modes#story'
+          linkLabel: 'See details',
+          href: '#'
         }
       ]
     },


### PR DESCRIPTION
## Summary
- refresh the home page mode card descriptions in English and Hungarian with spoiler-free 5-player raid, endless wave, and exploration messaging
- standardise the CTA copy to "See details" and retune the feature bullets for each mode
- point the card links to placeholders until dedicated subpages exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7211a3b88325ac7f5c3587b31439