### PR TITLE
Add progression teaser marketing page

### DIFF
--- a/app/(marketing)/progression/page.tsx
+++ b/app/(marketing)/progression/page.tsx
@@ -1,0 +1,56 @@
+import type { Metadata } from 'next';
+import SiteLayout from '../../../components/SiteLayout';
+import { getDictionary } from '../../../lib/i18n/dictionaries';
+import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
+import { createStaticPageMetadata } from '../../../lib/seo';
+import { locales } from '../../../lib/i18n/config';
+
+export function generateStaticParams(): Record<string, never>[] {
+  return locales.map(() => ({}));
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
+  const dictionary = getDictionary(locale);
+  return createStaticPageMetadata(locale, dictionary, '/progression', 'progression');
+}
+
+export default async function ProgressionPage() {
+  const locale = await resolveRequestLocale();
+  const dictionary = getDictionary(locale);
+  const sections = dictionary.progression.sections;
+
+  return (
+    <SiteLayout locale={locale} dictionary={dictionary}>
+      <div className="mx-auto max-w-5xl px-4 py-16 space-y-16">
+        <header>
+          <h1 className="text-3xl md:text-4xl font-bold">{dictionary.progression.title}</h1>
+          <p className="mt-4 max-w-3xl text-base md:text-lg opacity-90">{dictionary.progression.intro}</p>
+        </header>
+
+        <div className="space-y-12">
+          {sections.map(section => (
+            <section key={section.id} id={section.id} aria-labelledby={`${section.id}-title`} className="scroll-mt-24">
+              <div className="rounded-3xl border border-white/10 bg-white/5 p-8 md:p-10 shadow-lg shadow-black/20">
+                <div className="md:max-w-xl">
+                  <h2 id={`${section.id}-title`} className="text-2xl md:text-3xl font-semibold">
+                    {section.title}
+                  </h2>
+                  <p className="mt-3 text-sm md:text-base opacity-80">{section.summary}</p>
+                </div>
+                <ul className="mt-6 space-y-3 text-sm md:text-base opacity-90">
+                  {section.bullets.map(point => (
+                    <li key={point} className="flex items-start gap-3">
+                      <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-accentB" />
+                      <span>{point}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </SiteLayout>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -66,6 +66,7 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
       [
         dictionary.nav.modes,
         dictionary.nav.modesPage,
+        dictionary.nav.progression,
         dictionary.nav.characters,
         dictionary.nav.media,
         dictionary.nav.roadmap,

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -13,6 +13,7 @@ export const enDictionary: Dictionary = {
       roadmap: { label: 'Roadmap', href: '#roadmap' },
       community: { label: 'Community', href: '#community' },
       modesPage: { label: 'Detailed game modes', href: '/modes' },
+      progression: { label: 'Progression teaser', href: '/progression' },
       presskit: { label: 'Presskit', href: '/presskit' }
     },
     wishlistCta: 'Wishlist on Steam',
@@ -105,11 +106,11 @@ export const enDictionary: Dictionary = {
         }
       ]
     },
-    modes: {
-      title: 'Game Modes',
-      cards: [
-        {
-          title: 'Raid Boss Arena',
+  modes: {
+    title: 'Game Modes',
+    cards: [
+      {
+        title: 'Raid Boss Arena',
           description:
             "Drop into a five-player co-op boss gauntlet where every arena reveals layered mechanics without spoiling the finale. Master tells, stagger windows, and arena hazards to carve openings for your Resonators. Coordinated cooldowns and revives decide whether the squad extracts rare materials or wipes.",
           points: [
@@ -143,11 +144,47 @@ export const enDictionary: Dictionary = {
           ],
           linkLabel: 'See details',
           href: '#'
-        }
-      ]
-    },
-    characters: {
-      title: 'Resonators',
+      }
+    ]
+  },
+  progression: {
+    title: 'Progression teaser',
+    intro: 'A spoiler-free glimpse at how squads grow in AIKA World before full reveals.',
+    sections: [
+      {
+        id: 'resonance-skill',
+        title: 'Resonance skill',
+        summary: 'Signature resonance bursts deepen with coordinated play without exposing the complete skill web.',
+        bullets: [
+          'Chain resonance windows to unlock optional augment slots that alter your ultimate flow.',
+          'Earn resonance sparks from flawless clears to reroute ability behaviours between missions.',
+          'Blend support catalysts to extend combo uptime and rewrite finisher effects for the squad.'
+        ]
+      },
+      {
+        id: 'gear-evolution',
+        title: 'Gear evolution',
+        summary: 'Weapons and suits adapt through modular crafting loops instead of tier spreadsheets.',
+        bullets: [
+          'Refine expedition drops into adaptive cores that shift perk loadouts per activity.',
+          'Slot evolution plates to morph silhouettes and add traversal bonuses without revealing stats.',
+          'Trade duplicate finds for forge favours that fast-track bespoke weapon paths.'
+        ]
+      },
+      {
+        id: 'hub-customization',
+        title: 'Hub customization',
+        summary: 'Your safe hub grows with mood pieces and utilities as bonds deepen—no plot spoilers.',
+        bullets: [
+          'Curate district wings with earned decor sets that boost resting bonuses.',
+          'Unlock rehearsal rooms that rotate social buffs and mini training encounters.',
+          'Commission ambient tracks and lighting presets to broadcast your squad identity.'
+        ]
+      }
+    ]
+  },
+  characters: {
+    title: 'Resonators',
       description: 'Pick your resonance. Each of the five girls excels at a different specialty.',
       cards: [
         { slug: 'akari', name: 'Akari', role: 'Fire', color: 'accentA' },
@@ -390,6 +427,11 @@ export const enDictionary: Dictionary = {
         description:
           'Detailed overview of the Raid Boss Arena and Infest Survival modes: mechanics, rewards and team roles in AIKA World.',
         ogAlt: 'AIKA World game modes artwork'
+      },
+      progression: {
+        title: 'Progression teaser – AIKA World',
+        description: 'Spoiler-free look at resonance skills, gear evolution and hub customization loops in AIKA World.',
+        ogAlt: 'AIKA World progression teaser artwork'
       },
       characters: {
         title: 'Resonators – AIKA World',

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -13,6 +13,7 @@ export const huDictionary: Dictionary = {
       roadmap: { label: 'Roadmap', href: '#roadmap' },
       community: { label: 'Közösség', href: '#community' },
       modesPage: { label: 'Részletes játékmódok', href: '/hu/modes' },
+      progression: { label: 'Fejlődés teaser', href: '/hu/progression' },
       presskit: { label: 'Presskit', href: '/hu/presskit' }
     },
     wishlistCta: 'Wishlist a Steamen',
@@ -105,11 +106,11 @@ export const huDictionary: Dictionary = {
         }
       ]
     },
-    modes: {
-      title: 'Játékmódok',
-      cards: [
-        {
-          title: 'Raid Boss Arena',
+  modes: {
+    title: 'Játékmódok',
+    cards: [
+      {
+        title: 'Raid Boss Arena',
           description:
             'Öt fős kooperatív boss aréna, ahol a pályák rétegről rétegre tárják fel a mechanikákat, spoilerek nélkül. Olvasd a teleket, kezeld a fázisváltásokat, és védd a csapatot a csapdáktól. A koordinált ultik, élesztések és pozíciócserék döntik el, hogy zsákmányolsz vagy wipe-olsz.',
           points: [
@@ -292,6 +293,43 @@ export const huDictionary: Dictionary = {
       }
     ]
   },
+  progression: {
+    title: 'Fejlődés teaser',
+    intro: 'Spoilermentes ízelítő arról, hogyan fejlődik a csapat az AIKA Worldben.',
+    sections: [
+      {
+        id: 'resonance-skill',
+        title: 'Rezonancia-képesség',
+        summary: 'A szignatúra rezonancia végső koordinált játékkal mélyül, a teljes képességfa felfedése nélkül.',
+        bullets: [
+          'Fűzd össze a rezonancia ablakokat, hogy opcionális augment slotokat oldj fel és átformáld az ulti ritmusát.',
+          'Tökéletes teljesítésekből rezonancia-szikrákat gyűjtesz, amelyekkel küldetések között átírhatod a képességviselkedést.',
+          'Támogató katalizátorokkal kitolod a kombóidőt, és új befejező hatásokat hangolsz a csapatnak.'
+        ]
+      },
+      {
+        id: 'gear-evolution',
+        title: 'Felszerelés evolúció',
+        summary: 'A fegyverek és öltözékek moduláris kraftolással alkalmazkodnak, tier táblázatok nélkül.',
+        bullets: [
+          'Az expedíciós droppokból adaptív magokat finomítasz, amelyek aktivitásonként átrendezik a perk készletet.',
+          'Evolúciós lapkákat pattintasz a páncélra, hogy formát és mozgásbónuszokat válts statisztika-spoiler nélkül.',
+          'A duplikált leleteket kovácsműhely-szívességekre cseréled, így saját fegyverútvonalakat gyorsítasz.'
+        ]
+      },
+      {
+        id: 'hub-customization',
+        title: 'Hub testreszabás',
+        summary:
+          'A biztonságos hub hangulati elemekkel és hasznos funkciókkal bővül, ahogy mélyülnek a kötelékek – történetspoilerek nélkül.',
+        bullets: [
+          'Negyedszárnyakat rendezel be megszerzett dekor szettekkel, amelyek pihenési bónuszokat adnak.',
+          'Próbaszobákat nyitsz, ahol forgó közösségi buffok és mini edzések érhetők el.',
+          'Ambient zenéket és fény preseteket rendelsz meg, hogy sugározd a csapat identitását.'
+        ]
+      }
+    ]
+  },
   charactersPage: {
     breadcrumb: 'Karakterek',
     heading: 'AIKA World Rezonátorok',
@@ -391,6 +429,12 @@ export const huDictionary: Dictionary = {
         description:
           'Részletes áttekintés a Raid Boss Arena és az Infest Survival módokról: mechanikák, jutalmak, csapat szerepek az AIKA Worldben.',
         ogAlt: 'AIKA World játékmódok grafika'
+      },
+      progression: {
+        title: 'Fejlődés teaser – AIKA World',
+        description:
+          'Spoilermentes betekintés a rezonancia-képességekbe, a felszerelés evolúciójába és a hub testreszabásába az AIKA Worldben.',
+        ogAlt: 'AIKA World fejlődés teaser grafika'
       },
       characters: {
         title: 'Rezonátorok – AIKA World',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -105,6 +105,19 @@ export type ModesDictionary = {
   }[];
 };
 
+export type ProgressionSectionDictionary = {
+  id: string;
+  title: string;
+  summary: string;
+  bullets: string[];
+};
+
+export type ProgressionDictionary = {
+  title: string;
+  intro: string;
+  sections: ProgressionSectionDictionary[];
+};
+
 export type CharactersDictionary = {
   breadcrumb: string;
   heading: string;
@@ -220,6 +233,7 @@ export type HeaderDictionary = {
     roadmap: HeaderNavItem;
     community: HeaderNavItem;
     modesPage: HeaderNavItem;
+    progression: HeaderNavItem;
     presskit: HeaderNavItem;
   };
   wishlistCta: string;
@@ -253,6 +267,7 @@ export type SeoDictionary = {
   pages: {
     home: { title: string; description: string; ogAlt: string };
     modes: { title: string; description: string; ogAlt: string };
+    progression: { title: string; description: string; ogAlt: string };
     characters: { title: string; description: string };
     character: {
       description: (character: Character) => string;
@@ -276,6 +291,7 @@ export type Dictionary = {
   footer: FooterDictionary;
   home: HomeDictionary;
   modes: ModesDictionary;
+  progression: ProgressionDictionary;
   charactersPage: CharactersDictionary;
   characterPage: CharacterPageDictionary;
   presskit: PresskitDictionary;


### PR DESCRIPTION
## Summary
- add a localized marketing route for the progression teaser content and metadata
- extend header navigation and i18n dictionaries with progression copy in English and Hungarian
- wire up SEO entries for the new page

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68de7335984483258056966e8853dbf4