### PR TITLE
Add community hub cards and program landing pages

### DIFF
--- a/app/(marketing)/creator-program/page.tsx
+++ b/app/(marketing)/creator-program/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from 'next';
+import SiteLayout from '../../../components/SiteLayout';
+import { getDictionary } from '../../../lib/i18n/dictionaries';
+import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
+import { createStaticPageMetadata } from '../../../lib/seo';
+import { locales } from '../../../lib/i18n/config';
+
+export function generateStaticParams(): Record<string, never>[] {
+  return locales.map(() => ({}));
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
+  const dictionary = getDictionary(locale);
+  return createStaticPageMetadata(locale, dictionary, '/creator-program', 'creatorProgram');
+}
+
+export default async function CreatorProgramPage() {
+  const locale = await resolveRequestLocale();
+  const dictionary = getDictionary(locale);
+  const pageDictionary = dictionary.creatorProgram;
+  const basePath = locale === 'hu' ? '/hu' : '';
+  const ctaHref = pageDictionary.cta.href.startsWith('/')
+    ? `${basePath}${pageDictionary.cta.href}`
+    : pageDictionary.cta.href;
+
+  return (
+    <SiteLayout locale={locale} dictionary={dictionary}>
+      <div className="mx-auto max-w-5xl px-4 py-16 space-y-16">
+        <header className="space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-[0.22em] text-accentB">
+            {pageDictionary.eyebrow}
+          </p>
+          <h1 className="text-3xl font-bold md:text-4xl">{pageDictionary.title}</h1>
+          <p className="text-base opacity-90 md:text-lg">{pageDictionary.intro}</p>
+          <div className="pt-2">
+            <a
+              href={ctaHref}
+              className="inline-flex items-center gap-2 rounded-full bg-accentB px-4 py-2 text-sm font-semibold text-black transition hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            >
+              {pageDictionary.cta.label}
+              <span aria-hidden>→</span>
+            </a>
+            <p className="mt-2 text-xs opacity-70 md:text-sm">{pageDictionary.cta.note}</p>
+          </div>
+        </header>
+
+        <div className="space-y-12">
+          {pageDictionary.sections.map(section => (
+            <section
+              key={section.id}
+              id={section.id}
+              aria-labelledby={`${section.id}-title`}
+              className="rounded-3xl border border-white/10 bg-white/5 p-8 md:p-10 shadow-lg shadow-black/20"
+            >
+              <div className="md:max-w-2xl">
+                <h2 id={`${section.id}-title`} className="text-2xl font-semibold md:text-3xl">
+                  {section.title}
+                </h2>
+                <p className="mt-3 text-sm opacity-80 md:text-base">{section.description}</p>
+              </div>
+              {section.bullets?.length ? (
+                <ul className="mt-6 space-y-3 text-sm opacity-90 md:text-base">
+                  {section.bullets.map(point => (
+                    <li key={point} className="flex items-start gap-3">
+                      <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-accentB" />
+                      <span>{point}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </section>
+          ))}
+        </div>
+
+        <section aria-labelledby="faq-title" className="space-y-6">
+          <div className="md:max-w-3xl">
+            <h2 id="faq-title" className="text-2xl font-semibold md:text-3xl">
+              {pageDictionary.faqTitle}
+            </h2>
+          </div>
+          <div className="space-y-6">
+            {pageDictionary.faqs.map((faq, index) => (
+              <div
+                key={`${faq.question}-${index}`}
+                className="rounded-2xl border border-white/10 bg-white/5 p-6"
+              >
+                <h3 className="text-lg font-semibold md:text-xl">{faq.question}</h3>
+                <p className="mt-2 text-sm opacity-80 md:text-base">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </SiteLayout>
+  );
+}

--- a/app/(marketing)/playtests/page.tsx
+++ b/app/(marketing)/playtests/page.tsx
@@ -1,0 +1,97 @@
+import type { Metadata } from 'next';
+import SiteLayout from '../../../components/SiteLayout';
+import { getDictionary } from '../../../lib/i18n/dictionaries';
+import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
+import { createStaticPageMetadata } from '../../../lib/seo';
+import { locales } from '../../../lib/i18n/config';
+
+export function generateStaticParams(): Record<string, never>[] {
+  return locales.map(() => ({}));
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
+  const dictionary = getDictionary(locale);
+  return createStaticPageMetadata(locale, dictionary, '/playtests', 'playtests');
+}
+
+export default async function PlaytestsPage() {
+  const locale = await resolveRequestLocale();
+  const dictionary = getDictionary(locale);
+  const pageDictionary = dictionary.playtests;
+  const basePath = locale === 'hu' ? '/hu' : '';
+  const ctaHref = pageDictionary.cta.href.startsWith('/')
+    ? `${basePath}${pageDictionary.cta.href}`
+    : pageDictionary.cta.href;
+
+  return (
+    <SiteLayout locale={locale} dictionary={dictionary}>
+      <div className="mx-auto max-w-5xl px-4 py-16 space-y-16">
+        <header className="space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-[0.22em] text-accentB">
+            {pageDictionary.eyebrow}
+          </p>
+          <h1 className="text-3xl font-bold md:text-4xl">{pageDictionary.title}</h1>
+          <p className="text-base opacity-90 md:text-lg">{pageDictionary.intro}</p>
+          <div className="pt-2">
+            <a
+              href={ctaHref}
+              className="inline-flex items-center gap-2 rounded-full bg-accentB px-4 py-2 text-sm font-semibold text-black transition hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+            >
+              {pageDictionary.cta.label}
+              <span aria-hidden>→</span>
+            </a>
+            <p className="mt-2 text-xs opacity-70 md:text-sm">{pageDictionary.cta.note}</p>
+          </div>
+        </header>
+
+        <div className="space-y-12">
+          {pageDictionary.sections.map(section => (
+            <section
+              key={section.id}
+              id={section.id}
+              aria-labelledby={`${section.id}-title`}
+              className="rounded-3xl border border-white/10 bg-white/5 p-8 md:p-10 shadow-lg shadow-black/20"
+            >
+              <div className="md:max-w-2xl">
+                <h2 id={`${section.id}-title`} className="text-2xl font-semibold md:text-3xl">
+                  {section.title}
+                </h2>
+                <p className="mt-3 text-sm opacity-80 md:text-base">{section.description}</p>
+              </div>
+              {section.bullets?.length ? (
+                <ul className="mt-6 space-y-3 text-sm opacity-90 md:text-base">
+                  {section.bullets.map(point => (
+                    <li key={point} className="flex items-start gap-3">
+                      <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-accentB" />
+                      <span>{point}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </section>
+          ))}
+        </div>
+
+        <section aria-labelledby="faq-title" className="space-y-6">
+          <div className="md:max-w-3xl">
+            <h2 id="faq-title" className="text-2xl font-semibold md:text-3xl">
+              {pageDictionary.faqTitle}
+            </h2>
+          </div>
+          <div className="space-y-6">
+            {pageDictionary.faqs.map((faq, index) => (
+              <div
+                key={`${faq.question}-${index}`}
+                className="rounded-2xl border border-white/10 bg-white/5 p-6"
+              >
+                <h3 className="text-lg font-semibold md:text-xl">{faq.question}</h3>
+                <p className="mt-2 text-sm opacity-80 md:text-base">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </SiteLayout>
+  );
+}

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -36,6 +36,18 @@ export default function HomePage({
 
   const basePath = useMemo(() => (locale === 'hu' ? '/hu' : ''), [locale]);
 
+  const resolveLocalizedHref = (href: string) => {
+    if (!href) {
+      return '#';
+    }
+
+    if (href.startsWith('#') || href.startsWith('http')) {
+      return href;
+    }
+
+    return `${basePath}${href}`;
+  };
+
   const openLightbox = (index: number) => {
     setLightboxIndex(index);
   };
@@ -271,17 +283,41 @@ export default function HomePage({
       <section id="community" className="mx-auto max-w-6xl px-4 py-16">
         <h2 className="text-2xl md:text-3xl font-bold">{dictionary.community.title}</h2>
         <p className="mt-2 opacity-90">{dictionary.community.description}</p>
-        <div className="mt-6 flex flex-col sm:flex-row gap-3">
-          {discordUrl && (
-            <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href={discordUrl}>
-              {dictionary.community.discordCta}
-            </a>
-          )}
-          {steamUrl && (
-            <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href={steamUrl}>
-              {dictionary.community.wishlistCta}
-            </a>
-          )}
+
+        <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3">
+          {dictionary.community.cards.map(card => {
+            const href = resolveLocalizedHref(card.ctaHref);
+
+            return (
+              <div
+                key={card.id}
+                className="flex h-full flex-col rounded-2xl border border-white/10 bg-white/5 p-6"
+              >
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-accentB">
+                  {card.eyebrow}
+                </p>
+                <h3 className="mt-3 text-xl font-semibold">{card.title}</h3>
+                <p className="mt-3 text-sm md:text-base opacity-80">{card.description}</p>
+                <div className="mt-auto pt-6 flex flex-col gap-2">
+                  <a
+                    href={href}
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-accentB px-4 py-2 text-sm font-semibold text-black transition hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                  >
+                    {card.ctaLabel}
+                    <span aria-hidden>→</span>
+                  </a>
+                  {card.note && <p className="text-xs opacity-70">{card.note}</p>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div id="community-newsletter" className="mt-12 max-w-xl">
+          <h3 className="text-xl font-semibold">{dictionary.community.newsletterTitle}</h3>
+          <p className="mt-2 text-sm md:text-base opacity-80">
+            {dictionary.community.newsletterDescription}
+          </p>
         </div>
 
         <form id="newsletter" className="mt-6 max-w-md" onSubmit={handleSubmit}>

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -147,42 +147,6 @@ export const enDictionary: Dictionary = {
       }
     ]
   },
-  progression: {
-    title: 'Progression teaser',
-    intro: 'A spoiler-free glimpse at how squads grow in AIKA World before full reveals.',
-    sections: [
-      {
-        id: 'resonance-skill',
-        title: 'Resonance skill',
-        summary: 'Signature resonance bursts deepen with coordinated play without exposing the complete skill web.',
-        bullets: [
-          'Chain resonance windows to unlock optional augment slots that alter your ultimate flow.',
-          'Earn resonance sparks from flawless clears to reroute ability behaviours between missions.',
-          'Blend support catalysts to extend combo uptime and rewrite finisher effects for the squad.'
-        ]
-      },
-      {
-        id: 'gear-evolution',
-        title: 'Gear evolution',
-        summary: 'Weapons and suits adapt through modular crafting loops instead of tier spreadsheets.',
-        bullets: [
-          'Refine expedition drops into adaptive cores that shift perk loadouts per activity.',
-          'Slot evolution plates to morph silhouettes and add traversal bonuses without revealing stats.',
-          'Trade duplicate finds for forge favours that fast-track bespoke weapon paths.'
-        ]
-      },
-      {
-        id: 'hub-customization',
-        title: 'Hub customization',
-        summary: 'Your safe hub grows with mood pieces and utilities as bonds deepen—no plot spoilers.',
-        bullets: [
-          'Curate district wings with earned decor sets that boost resting bonuses.',
-          'Unlock rehearsal rooms that rotate social buffs and mini training encounters.',
-          'Commission ambient tracks and lighting presets to broadcast your squad identity.'
-        ]
-      }
-    ]
-  },
   characters: {
     title: 'Resonators',
       description: 'Pick your resonance. Each of the five girls excels at a different specialty.',
@@ -224,10 +188,42 @@ export const enDictionary: Dictionary = {
       ]
     },
     community: {
-      title: 'Community & Newsletter',
-      description: 'Join the Discord and sign up for playtest news.',
-      discordCta: 'Join Discord',
-      wishlistCta: 'Wishlist on Steam'
+      title: 'Community hub',
+      description: 'Stay close to the squad with our flagship programs and upcoming challenges.',
+      cards: [
+        {
+          id: 'playtests',
+          eyebrow: 'Hands-on access',
+          title: 'Playtests',
+          description:
+            'Apply to hop into curated co-op sessions, share feedback directly with the team and help us fine-tune combat pacing.',
+          note: 'Invites roll out in planned waves.',
+          ctaLabel: 'Apply',
+          ctaHref: '/playtests'
+        },
+        {
+          id: 'creator-program',
+          eyebrow: 'Signal boost',
+          title: 'Creator Program',
+          description:
+            'Creators get early briefings, capture tips and co-stream opportunities so you can spotlight AIKA World with confidence.',
+          note: 'Creator onboarding opens in planned waves.',
+          ctaLabel: 'Apply',
+          ctaHref: '/creator-program'
+        },
+        {
+          id: 'community-challenges',
+          eyebrow: 'Squad goals',
+          title: 'Community Challenges',
+          description:
+            'Seasonal squad objectives, hub events and puzzle drops launch via Discord and the newsletter for coordinated play.',
+          note: 'Challenge briefings release in planned waves.',
+          ctaLabel: 'Read more',
+          ctaHref: '#community-newsletter'
+        }
+      ],
+      newsletterTitle: 'Stay notified',
+      newsletterDescription: 'Subscribe for playtest waves, creator beats and challenge announcements.'
     },
     newsletter: {
       emailLabel: 'Email address',
@@ -328,6 +324,166 @@ export const enDictionary: Dictionary = {
         ]
       }
     ]
+  },
+  progression: {
+    title: 'Progression teaser',
+    intro: 'A spoiler-free glimpse at how squads grow in AIKA World before full reveals.',
+    sections: [
+      {
+        id: 'resonance-skill',
+        title: 'Resonance skill',
+        summary: 'Signature resonance bursts deepen with coordinated play without exposing the complete skill web.',
+        bullets: [
+          'Chain resonance windows to unlock optional augment slots that alter your ultimate flow.',
+          'Earn resonance sparks from flawless clears to reroute ability behaviours between missions.',
+          'Blend support catalysts to extend combo uptime and rewrite finisher effects for the squad.'
+        ]
+      },
+      {
+        id: 'gear-evolution',
+        title: 'Gear evolution',
+        summary: 'Weapons and suits adapt through modular crafting loops instead of tier spreadsheets.',
+        bullets: [
+          'Refine expedition drops into adaptive cores that shift perk loadouts per activity.',
+          'Slot evolution plates to morph silhouettes and add traversal bonuses without revealing stats.',
+          'Trade duplicate finds for forge favours that fast-track bespoke weapon paths.'
+        ]
+      },
+      {
+        id: 'hub-customization',
+        title: 'Hub customization',
+        summary: 'Your safe hub grows with mood pieces and utilities as bonds deepen—no plot spoilers.',
+        bullets: [
+          'Curate district wings with earned decor sets that boost resting bonuses.',
+          'Unlock rehearsal rooms that rotate social buffs and mini training encounters.',
+          'Commission ambient tracks and lighting presets to broadcast your squad identity.'
+        ]
+      }
+    ]
+  },
+  playtests: {
+    eyebrow: 'Hands-on squads',
+    title: 'AIKA World Playtests',
+    intro:
+      'Apply to join curated co-op sessions that stress-test combat pacing, hub flow and onboarding. Selected squads explore focused builds with developer support, and invites ship in planned waves so everyone has room to report findings.',
+    sections: [
+      {
+        id: 'structure',
+        title: 'How sessions run',
+        description:
+          'Each playtest wave targets a specific objective and pairs your squad with on-call support from the team.',
+        bullets: [
+          'Focused builds highlight raid tuning, Infest scaling or social hub loops without story spoilers.',
+          'Session briefs outline goals, success metrics and checklist moments to watch for.',
+          'Developers staff feedback channels during every wave to clarify mechanics in real time.'
+        ]
+      },
+      {
+        id: 'expectations',
+        title: 'What we ask from testers',
+        description: 'We keep requirements lightweight, but we need actionable observations from each squad.',
+        bullets: [
+          'Play at least two sessions per wave and complete the quick debrief survey afterward.',
+          'Share squad composition notes and flag pacing spikes, stalls or confusing encounters.',
+          'Log bugs or blockers with reproduction steps inside the testing portal so we can follow up.'
+        ]
+      },
+      {
+        id: 'support',
+        title: 'Tools & support',
+        description:
+          'Every accepted squad gains access to private coordination spaces and structured reporting tools.',
+        bullets: [
+          'Private Discord channels with developer responders for live Q&A during test windows.',
+          'Template-based issue tracking that separates combat, UI and onboarding feedback.',
+          'Optional voice roundtables after each wave to prioritise hot topics for the next build.'
+        ]
+      }
+    ],
+    faqTitle: 'Frequently asked questions',
+    faqs: [
+      {
+        question: 'Who can apply?',
+        answer:
+          'Co-op players comfortable coordinating in English or Hungarian voice/text channels. We welcome friend groups and organised communities alike.'
+      },
+      {
+        question: 'How are invites sent?',
+        answer:
+          'We review submissions regularly, group them by hardware, region and experience level, then email accepted squads in planned waves with timing and onboarding details.'
+      },
+      {
+        question: 'Do I need to stream or record?',
+        answer:
+          'Recordings are optional. Share clips or notes if you capture footage, but priority goes to clear written feedback through the provided forms.'
+      }
+    ],
+    cta: {
+      label: 'Apply',
+      href: '#',
+      note: 'Application form placeholder — invite emails are dispatched in planned waves.'
+    }
+  },
+  creatorProgram: {
+    eyebrow: 'Share the resonance',
+    title: 'AIKA World Creator Program',
+    intro:
+      'Apply to collaborate on coverage, showcase Resonators and host co-op segments with direct studio support. We onboard creators in planned waves to keep every partnership personal.',
+    sections: [
+      {
+        id: 'who',
+        title: 'Who we partner with',
+        description: 'We prioritise storytellers who celebrate co-op energy and community vibes.',
+        bullets: [
+          'You publish consistent co-op, anime or action RPG content on platforms like YouTube, Twitch, TikTok or podcasts.',
+          'You cultivate respectful communities that blend hype with constructive insight.',
+          'You can align uploads or streams with our planned beats while keeping surprises intact.'
+        ]
+      },
+      {
+        id: 'benefits',
+        title: 'What you receive',
+        description: 'Creators get resources that make producing AIKA World content faster and more expressive.',
+        bullets: [
+          'Early briefings with lore context, system breakdowns and challenge overviews.',
+          'Capture kits, overlay packages and music beds cleared for streaming and editing.',
+          'Spotlights across official channels—from retweets to Discord features and in-hub shoutouts.'
+        ]
+      },
+      {
+        id: 'collaboration',
+        title: 'How collaboration works',
+        description: 'We treat creator partnerships as ongoing dialogues built around community impact.',
+        bullets: [
+          'Monthly sync calls to plan co-op segments, interviews or challenge coverage.',
+          'Shared content calendar highlighting planned waves for reveals and community events.',
+          'Direct access to a community manager who routes requests, assets and follow-up feedback.'
+        ]
+      }
+    ],
+    faqTitle: 'Frequently asked questions',
+    faqs: [
+      {
+        question: 'What platforms qualify?',
+        answer:
+          'Any channel with consistent storytelling or analysis around co-op games, anime worlds or character-driven action—YouTube, Twitch, TikTok, newsletters and podcasts all count.'
+      },
+      {
+        question: 'What content can I publish?',
+        answer:
+          'Guides, reaction segments, behind-the-scenes chats, community spotlights and co-op sessions are all welcome. We will flag spoiler-sensitive material ahead of time so you can plan safely.'
+      },
+      {
+        question: 'When will I hear back?',
+        answer:
+          'We evaluate applications continuously and respond in planned waves via email. If we cannot onboard immediately we keep your details for the next wave.'
+      }
+    ],
+    cta: {
+      label: 'Apply',
+      href: '#',
+      note: 'Application form placeholder — approvals roll out in planned waves.'
+    }
   },
   charactersPage: {
     breadcrumb: 'Characters',
@@ -432,6 +588,18 @@ export const enDictionary: Dictionary = {
         title: 'Progression teaser – AIKA World',
         description: 'Spoiler-free look at resonance skills, gear evolution and hub customization loops in AIKA World.',
         ogAlt: 'AIKA World progression teaser artwork'
+      },
+      playtests: {
+        title: 'Playtests – AIKA World',
+        description:
+          'Apply for AIKA World playtests to join planned waves, share feedback and tune co-op combat with the dev team.',
+        ogAlt: 'AIKA World playtests program graphic'
+      },
+      creatorProgram: {
+        title: 'Creator Program – AIKA World',
+        description:
+          'Join the AIKA World Creator Program for early briefings, capture kits and community spotlight opportunities released in planned waves.',
+        ogAlt: 'AIKA World creator program artwork'
       },
       characters: {
         title: 'Resonators – AIKA World',

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -188,10 +188,42 @@ export const huDictionary: Dictionary = {
       ]
     },
     community: {
-      title: 'Közösség & Feliratkozás',
-      description: 'Csatlakozz a Discordhoz és iratkozz fel a playtest hírekre.',
-      discordCta: 'Csatlakozz Discordon',
-      wishlistCta: 'Wishlist a Steamen'
+      title: 'Közösségi központ',
+      description: 'Maradj közel a csapathoz a zászlóshajó programokkal és közelgő kihívásokkal.',
+      cards: [
+        {
+          id: 'playtests',
+          eyebrow: 'Korai hozzáférés',
+          title: 'Playtestek',
+          description:
+            'Jelentkezz, hogy belenézz a kurált kooperatív buildekbe, add visszajelzésed közvetlenül a csapatnak, és velünk csiszold a harci tempót.',
+          note: 'Meghívók ütemezett hullámokban mennek ki.',
+          ctaLabel: 'Jelentkezem',
+          ctaHref: '/playtests'
+        },
+        {
+          id: 'creator-program',
+          eyebrow: 'Jelerősítés',
+          title: 'Creator Program',
+          description:
+            'Készítők előzetes brífeket, felvételi tippeket és közös stream lehetőségeket kapnak, hogy magabiztosan mutassák be az AIKA Worldöt.',
+          note: 'A készítői felvétel ütemezett hullámokban nyílik.',
+          ctaLabel: 'Jelentkezem',
+          ctaHref: '/creator-program'
+        },
+        {
+          id: 'community-challenges',
+          eyebrow: 'Csapatcélok',
+          title: 'Közösségi kihívások',
+          description:
+            'Szezonális csapatfeladatok, hub események és rejtvény dropok a Discordon és a hírlevélben indulnak a koordinált játékért.',
+          note: 'A kihívás brífek ütemezett hullámokban érkeznek.',
+          ctaLabel: 'Bővebben',
+          ctaHref: '#community-newsletter'
+        }
+      ],
+      newsletterTitle: 'Maradj értesült',
+      newsletterDescription: 'Iratkozz fel a playtest hullámokra, a készítői hírekre és a kihívás bejelentésekre.'
     },
     newsletter: {
       emailLabel: 'E-mail cím',
@@ -330,6 +362,130 @@ export const huDictionary: Dictionary = {
       }
     ]
   },
+  playtests: {
+    eyebrow: 'Korai csapatok',
+    title: 'AIKA World Playtestek',
+    intro:
+      'Jelentkezz, hogy kurált kooperatív sessionökben teszteld a harci tempót, a hub áramlást és az onboardingot. A kiválasztott squadok fókuszált buildeket kapnak fejlesztői támogatással. Meghívók ütemezett hullámokban érkeznek, így mindenkinek jut idő a visszajelzésre.',
+    sections: [
+      {
+        id: 'structure',
+        title: 'Hogyan futnak a sessionök',
+        description:
+          'Minden playtest hullám konkrét célt kap, és a csapatot közvetlenül elérhető fejlesztőkkel párosítjuk.',
+        bullets: [
+          'Fókusz build-ek raid finomhangolást, Infest skálázást vagy hub loopokat vizsgálnak spoiler nélkül.',
+          'A session brífek célokat, sikerkritériumokat és figyelendő pillanatokat adnak.',
+          'A fejlesztők minden hullám alatt jelen vannak a visszajelző csatornákban, hogy azonnal tisztázzák a mechanikákat.'
+        ]
+      },
+      {
+        id: 'expectations',
+        title: 'Mit várunk a tesztelőktől',
+        description: 'Könnyű elvárásokat tartunk, de minden csapattól használható megfigyeléseket kérünk.',
+        bullets: [
+          'Hullámonként legalább két sessiont játssz és töltsd ki a gyors összegző kérdőívet.',
+          'Oszd meg a squad összetételét, és jelezd, hol torpan vagy gyorsul túl a tempó.',
+          'A hibákat vagy blokkolókat reprodukciós lépésekkel logold a tesztelő portálon, hogy követni tudjuk.'
+        ]
+      },
+      {
+        id: 'support',
+        title: 'Eszközök és támogatás',
+        description:
+          'Minden elfogadott csapat privát egyeztető tereket és strukturált riport eszközöket kap.',
+        bullets: [
+          'Privát Discord csatornák fejlesztői válaszolókkal a teszt ablakok alatt.',
+          'Sablonos hibajegy-kezelés, ami szétválasztja a harc, UI és onboarding visszajelzéseket.',
+          'Opcionális voice roundtable beszélgetések minden hullám után a következő build fókuszainak priorizálására.'
+        ]
+      }
+    ],
+    faqTitle: 'Gyakori kérdések',
+    faqs: [
+      {
+        question: 'Kik jelentkezhetnek?',
+        answer:
+          'Bárki, aki szeret kooperatívban játszani és angol vagy magyar voice/text csatornákon tud egyeztetni. Baráti csapatokat és szervezett közösségeket is várunk.'
+      },
+      {
+        question: 'Hogyan külditek ki a meghívókat?',
+        answer:
+          'Heti rendszerességgel átnézzük a jelentkezéseket, hardver, régió és tapasztalat alapján csoportosítunk, majd ütemezett hullámokban küldünk e-mailt az elfogadott squadoknak az időzítéssel és onboarding infóval.'
+      },
+      {
+        question: 'Kell streamelnem vagy felvennem?',
+        answer:
+          'Nem kötelező. Ha rögzítesz, oszd meg a klipeket vagy jegyzeteket, de a legfontosabb, hogy a biztosított űrlapokon tiszta visszajelzést adj.'
+      }
+    ],
+    cta: {
+      label: 'Jelentkezem',
+      href: '#',
+      note: 'Ideiglenes jelentkezési űrlap – meghívó e-mailek ütemezett hullámokban érkeznek.'
+    }
+  },
+  creatorProgram: {
+    eyebrow: 'Oszd meg a rezonanciát',
+    title: 'AIKA World Creator Program',
+    intro:
+      'Jelentkezz, hogy közösen készítsünk tartalmat, mutasd be a Rezonátorokat és vezess kooperatív blokkokat közvetlen stúdiótámogatással. A készítőket személyes figyelem miatt ütemezett hullámokban vesszük fel.',
+    sections: [
+      {
+        id: 'who',
+        title: 'Kikkel dolgozunk együtt',
+        description: 'Azokat részesítjük előnyben, akik a kooperatív energiát és a közösségi hangulatot emelik ki.',
+        bullets: [
+          'Rendszeresen publikálsz kooperatív, anime vagy akció RPG tartalmat YouTube-on, Twitch-en, TikTokon vagy podcast formában.',
+          'Olyan közösséget építesz, ahol a hype és az építő kritika egyensúlyban van.',
+          'A publikálást az ütemezett beatjeinkhez tudod igazítani anélkül, hogy lelőnéd a meglepetéseket.'
+        ]
+      },
+      {
+        id: 'benefits',
+        title: 'Mit kapsz tőlünk',
+        description: 'Olyan eszközöket adunk, amelyek gyorsítják és színesítik az AIKA World tartalomgyártást.',
+        bullets: [
+          'Előzetes brífek lore kontextussal, rendszer bontásokkal és kihívás áttekintésekkel.',
+          'Felvételi csomagok, overlay szettek és streamelhető zenék, amelyeket szabadon használhatsz.',
+          'Kiemelések az official csatornákon – retweetektől a Discord feature-ökig és hub shoutoutokig.'
+        ]
+      },
+      {
+        id: 'collaboration',
+        title: 'Hogyan zajlik az együttműködés',
+        description: 'A partneri kapcsolat folyamatos párbeszéd, aminek fókusza a közösségi hatás.',
+        bullets: [
+          'Havi egyeztető hívások kooperatív blokkok, interjúk vagy kihívás coverage megtervezéséhez.',
+          'Megosztott tartalomnaptár, ami jelzi a reveal-ek és közösségi események ütemezett hullámait.',
+          'Közvetlen community manager, aki intézi a kéréseket, asseteket és az utókövetést.'
+        ]
+      }
+    ],
+    faqTitle: 'Gyakori kérdések',
+    faqs: [
+      {
+        question: 'Milyen platformok számítanak?',
+        answer:
+          'Bármely csatorna, ahol következetes történetmesélés vagy elemzés van kooperatív játékokról, anime világokról vagy karakterközpontú akcióról – YouTube, Twitch, TikTok, hírlevél és podcast is belefér.'
+      },
+      {
+        question: 'Milyen tartalmat készíthetek?',
+        answer:
+          'Üdvözlünk guide-okat, reakciókat, backstage beszélgetéseket, közösségi spotlightokat és co-op sessionöket is. Előre jelezzük, ha spoilerérzékeny anyag közeledik, hogy biztonságosan tervezhess.'
+      },
+      {
+        question: 'Mikor kapok visszajelzést?',
+        answer:
+          'Folyamatosan értékeljük a jelentkezéseket és e-mailben válaszolunk ütemezett hullámokban. Ha most nem fér bele, megőrizzük az adataid a következő körre.'
+      }
+    ],
+    cta: {
+      label: 'Jelentkezem',
+      href: '#',
+      note: 'Ideiglenes jelentkezési űrlap – jóváhagyások ütemezett hullámokban mennek ki.'
+    }
+  },
   charactersPage: {
     breadcrumb: 'Karakterek',
     heading: 'AIKA World Rezonátorok',
@@ -435,6 +591,18 @@ export const huDictionary: Dictionary = {
         description:
           'Spoilermentes betekintés a rezonancia-képességekbe, a felszerelés evolúciójába és a hub testreszabásába az AIKA Worldben.',
         ogAlt: 'AIKA World fejlődés teaser grafika'
+      },
+      playtests: {
+        title: 'Playtestek – AIKA World',
+        description:
+          'Jelentkezz az AIKA World playtestekre, lépj be ütemezett hullámokba, ossz meg visszajelzést és hangold a kooperatív harcot a fejlesztőkkel.',
+        ogAlt: 'AIKA World playtest program grafika'
+      },
+      creatorProgram: {
+        title: 'Creator Program – AIKA World',
+        description:
+          'Csatlakozz az AIKA World Creator Programhoz előzetes brífekért, felvételi csomagokért és közösségi spotlightokért, amelyek ütemezett hullámokban érkeznek.',
+        ogAlt: 'AIKA World creator program grafika'
       },
       characters: {
         title: 'Rezonátorok – AIKA World',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -81,10 +81,45 @@ export type HomeDictionary = {
   community: {
     title: string;
     description: string;
-    discordCta: string;
-    wishlistCta: string;
+    cards: {
+      id: string;
+      eyebrow: string;
+      title: string;
+      description: string;
+      note?: string;
+      ctaLabel: string;
+      ctaHref: string;
+    }[];
+    newsletterTitle: string;
+    newsletterDescription: string;
   };
   newsletter: NewsletterDictionary;
+};
+
+export type ProgramPageSectionDictionary = {
+  id: string;
+  title: string;
+  description: string;
+  bullets?: string[];
+};
+
+export type ProgramPageFaqDictionary = {
+  question: string;
+  answer: string;
+};
+
+export type ProgramPageDictionary = {
+  eyebrow: string;
+  title: string;
+  intro: string;
+  sections: ProgramPageSectionDictionary[];
+  faqTitle: string;
+  faqs: ProgramPageFaqDictionary[];
+  cta: {
+    label: string;
+    href: string;
+    note: string;
+  };
 };
 
 export type ModesDictionary = {
@@ -268,6 +303,8 @@ export type SeoDictionary = {
     home: { title: string; description: string; ogAlt: string };
     modes: { title: string; description: string; ogAlt: string };
     progression: { title: string; description: string; ogAlt: string };
+    playtests: { title: string; description: string; ogAlt: string };
+    creatorProgram: { title: string; description: string; ogAlt: string };
     characters: { title: string; description: string };
     character: {
       description: (character: Character) => string;
@@ -292,6 +329,8 @@ export type Dictionary = {
   home: HomeDictionary;
   modes: ModesDictionary;
   progression: ProgressionDictionary;
+  playtests: ProgramPageDictionary;
+  creatorProgram: ProgramPageDictionary;
   charactersPage: CharactersDictionary;
   characterPage: CharacterPageDictionary;
   presskit: PresskitDictionary;


### PR DESCRIPTION
## Summary
- replace the home community section with a responsive card grid and newsletter lead-in
- add English and Hungarian copy plus SEO entries for the playtests and creator program pages
- create localized playtests and creator program marketing pages with placeholder CTAs

## Testing
- npm run validate:translations

------
https://chatgpt.com/codex/tasks/task_e_68de75d8210c83258436c9838eaf61cb