### PR TITLE
Hozzáadott marketing FAQ oldal

### DIFF
--- a/app/(marketing)/faq/page.tsx
+++ b/app/(marketing)/faq/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next';
+import SiteLayout from '../../../components/SiteLayout';
+import { getDictionary } from '../../../lib/i18n/dictionaries';
+import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
+import { createStaticPageMetadata } from '../../../lib/seo';
+import { locales } from '../../../lib/i18n/config';
+
+export function generateStaticParams(): Record<string, never>[] {
+  return locales.map(() => ({}));
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await resolveRequestLocale();
+  const dictionary = getDictionary(locale);
+  return createStaticPageMetadata(locale, dictionary, '/faq', 'faq');
+}
+
+function AccordionItem({
+  question,
+  answer
+}: {
+  question: string;
+  answer: string;
+}) {
+  return (
+    <details className="group rounded-2xl border border-white/10 bg-white/5">
+      <summary className="flex cursor-pointer items-center justify-between gap-4 px-6 py-4 text-left text-lg font-semibold md:text-xl [&::-webkit-details-marker]:hidden">
+        <span>{question}</span>
+        <span aria-hidden className="text-accentB transition-transform duration-200 group-open:rotate-45">
+          +
+        </span>
+      </summary>
+      <div className="border-t border-white/10 px-6 py-4">
+        <p className="text-sm opacity-80 md:text-base">{answer}</p>
+      </div>
+    </details>
+  );
+}
+
+export default async function FaqPage() {
+  const locale = await resolveRequestLocale();
+  const dictionary = getDictionary(locale);
+  const pageDictionary = dictionary.faq;
+
+  return (
+    <SiteLayout locale={locale} dictionary={dictionary}>
+      <div className="mx-auto max-w-4xl px-4 py-16 space-y-12">
+        <header className="space-y-4">
+          <h1 className="text-3xl font-bold md:text-4xl">{pageDictionary.title}</h1>
+          <p className="text-base opacity-90 md:text-lg">{pageDictionary.intro}</p>
+        </header>
+
+        <section aria-label={pageDictionary.title} className="space-y-4">
+          {pageDictionary.items.map(item => (
+            <AccordionItem key={item.question} question={item.question} answer={item.answer} />
+          ))}
+        </section>
+      </div>
+    </SiteLayout>
+  );
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -71,6 +71,7 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
         dictionary.nav.media,
         dictionary.nav.roadmap,
         dictionary.nav.community,
+        dictionary.nav.faq,
         dictionary.nav.presskit
       ],
     [dictionary.nav]

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -14,6 +14,7 @@ export const enDictionary: Dictionary = {
       community: { label: 'Community', href: '#community' },
       modesPage: { label: 'Detailed game modes', href: '/modes' },
       progression: { label: 'Progression teaser', href: '/progression' },
+      faq: { label: 'FAQ', href: '/faq' },
       presskit: { label: 'Presskit', href: '/presskit' }
     },
     wishlistCta: 'Wishlist on Steam',
@@ -27,6 +28,7 @@ export const enDictionary: Dictionary = {
   footer: {
     legalHeading: 'Legal',
     legalLinks: [
+      { path: '/faq', label: 'FAQ' },
       { path: '/privacy', label: 'Privacy Policy' },
       { path: '/terms', label: 'Terms of Use' },
       { path: '/legal/copyright', label: 'Copyright / DMCA' },
@@ -485,6 +487,45 @@ export const enDictionary: Dictionary = {
       note: 'Application form placeholder — approvals roll out in planned waves.'
     }
   },
+  faq: {
+    title: 'AIKA World FAQ',
+    intro:
+      'Quick answers to the most common squad questions about platforms, progression and support.',
+    items: [
+      {
+        question: 'Which platforms are you targeting?',
+        answer: 'We are focusing on PC via Steam first while we evaluate additional platform partners.'
+      },
+      {
+        question: 'Is the whole game co-op?',
+        answer: 'Yes. Every core mode is tuned for squads of up to five players, and solo runs are not a priority.'
+      },
+      {
+        question: 'How do purchases work?',
+        answer: 'All monetization is optional and cosmetic only—no gameplay power or progression shortcuts.'
+      },
+      {
+        question: 'Will there be crossplay or cross-save?',
+        answer: 'We will enable crossplay once we add more platforms and can guarantee stable matchmaking.'
+      },
+      {
+        question: 'Which languages will be available?',
+        answer: 'English and Hungarian ship with full interface and subtitle support, with more localisations reviewed later.'
+      },
+      {
+        question: 'What is the minimum spec?',
+        answer: 'We recommend a modern quad-core CPU, 16 GB RAM and a GTX 1060 / RX 580 class GPU for 1080p play.'
+      },
+      {
+        question: 'Can I use a controller?',
+        answer: 'Yes. The PC build fully supports Xbox, PlayStation and Steam Input controllers.'
+      },
+      {
+        question: 'What release model are you following?',
+        answer: 'We plan a premium launch supported by free seasonal updates and optional cosmetic drops.'
+      }
+    ]
+  },
   charactersPage: {
     breadcrumb: 'Characters',
     heading: 'AIKA World Resonators',
@@ -614,6 +655,11 @@ export const enDictionary: Dictionary = {
       presskit: {
         title: 'AIKA World – Presskit',
         description: 'Downloadable logos, key art, screenshots and essential info for press.'
+      },
+      faq: {
+        title: 'FAQ – AIKA World',
+        description: 'Essential answers about platforms, co-op focus, cosmetic monetization and hardware needs.',
+        ogAlt: 'AIKA World FAQ overview graphic'
       },
       privacy: {
         title: 'Privacy Policy – AIKA World',

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -14,6 +14,7 @@ export const huDictionary: Dictionary = {
       community: { label: 'Közösség', href: '#community' },
       modesPage: { label: 'Részletes játékmódok', href: '/hu/modes' },
       progression: { label: 'Fejlődés teaser', href: '/hu/progression' },
+      faq: { label: 'GYIK', href: '/hu/faq' },
       presskit: { label: 'Presskit', href: '/hu/presskit' }
     },
     wishlistCta: 'Wishlist a Steamen',
@@ -27,6 +28,7 @@ export const huDictionary: Dictionary = {
   footer: {
     legalHeading: 'Jogi információk',
     legalLinks: [
+      { path: '/faq', label: 'GYIK' },
       { path: '/privacy', label: 'Adatkezelési tájékoztató' },
       { path: '/terms', label: 'Felhasználási feltételek' },
       { path: '/legal/copyright', label: 'Szerzői jog / DMCA' },
@@ -486,6 +488,45 @@ export const huDictionary: Dictionary = {
       note: 'Ideiglenes jelentkezési űrlap – jóváhagyások ütemezett hullámokban mennek ki.'
     }
   },
+  faq: {
+    title: 'AIKA World GYIK',
+    intro:
+      'Rövid válaszok a leggyakoribb platform, co-op és támogatási kérdésekre.',
+    items: [
+      {
+        question: 'Milyen platformokra céloztok?',
+        answer: 'Elsőként PC-re (Steam) fókuszálunk, a további platformpartnereket folyamatosan értékeljük.'
+      },
+      {
+        question: 'A játék teljesen kooperatív?',
+        answer: 'Igen. Minden fő mód maximum öt fős csapatokra van hangolva, az egyszemélyes futam nem központi cél.'
+      },
+      {
+        question: 'Hogyan működik a monetizáció?',
+        answer: 'Minden vásárlás opcionális és kizárólag kozmetikai, játékmeneti előny nélkül.'
+      },
+      {
+        question: 'Lesz crossplay vagy cross-save?',
+        answer: 'Amint új platformok csatlakoznak és stabil a matchmaking, bekapcsoljuk a crossplay támogatást.'
+      },
+      {
+        question: 'Milyen nyelvi támogatás várható?',
+        answer: 'Induláskor angol és magyar felületet és feliratokat adunk, további lokalizációkat később vizsgálunk.'
+      },
+      {
+        question: 'Mik a minimális gépigények?',
+        answer: 'Modern négymagos CPU, 16 GB RAM és GTX 1060 / RX 580 kategóriájú GPU ajánlott 1080p-re.'
+      },
+      {
+        question: 'Támogatjátok a kontrollereket?',
+        answer: 'Igen, a PC-s verzió teljes Xbox, PlayStation és Steam Input kompatibilitást kínál.'
+      },
+      {
+        question: 'Milyen megjelenési modellre számíthatunk?',
+        answer: 'Prémium rajt után ingyenes szezonális frissítéseket és opcionális kozmetikai csomagokat tervezünk.'
+      }
+    ]
+  },
   charactersPage: {
     breadcrumb: 'Karakterek',
     heading: 'AIKA World Rezonátorok',
@@ -617,6 +658,11 @@ export const huDictionary: Dictionary = {
       presskit: {
         title: 'AIKA World – Presskit',
         description: 'Letölthető logók, key artok, screenshotok és fontos információk az AIKA World sajtó számára.'
+      },
+      faq: {
+        title: 'GYIK – AIKA World',
+        description: 'Válaszok a legfontosabb platform, co-op fókusz, kozmetikai monetizáció és gépigény kérdésekre.',
+        ogAlt: 'AIKA World GYIK grafika'
       },
       privacy: {
         title: 'Adatvédelmi tájékoztató – AIKA World',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -122,6 +122,17 @@ export type ProgramPageDictionary = {
   };
 };
 
+export type FaqItemDictionary = {
+  question: string;
+  answer: string;
+};
+
+export type FaqDictionary = {
+  title: string;
+  intro: string;
+  items: FaqItemDictionary[];
+};
+
 export type ModesDictionary = {
   navLabel: string;
   heading: string;
@@ -269,6 +280,7 @@ export type HeaderDictionary = {
     community: HeaderNavItem;
     modesPage: HeaderNavItem;
     progression: HeaderNavItem;
+    faq: HeaderNavItem;
     presskit: HeaderNavItem;
   };
   wishlistCta: string;
@@ -312,6 +324,7 @@ export type SeoDictionary = {
       ogAlt: (character: Character) => string;
     };
     presskit: { title: string; description: string };
+    faq: { title: string; description: string; ogAlt: string };
     privacy: { title: string; description: string };
     terms: { title: string; description: string };
     legalCopyright: { title: string; description: string; ogAlt: string };
@@ -331,6 +344,7 @@ export type Dictionary = {
   progression: ProgressionDictionary;
   playtests: ProgramPageDictionary;
   creatorProgram: ProgramPageDictionary;
+  faq: FaqDictionary;
   charactersPage: CharactersDictionary;
   characterPage: CharacterPageDictionary;
   presskit: PresskitDictionary;


### PR DESCRIPTION
## Összegzés
- Új `/faq` marketing oldal létrehozása harmonikás kérdés-válasz megjelenéssel mindkét nyelven.
- A szótárak bővítése az FAQ tartalommal, SEO meta adatokkal, valamint a fejléc és lábléc linkjeivel.

## Tesztek
- `npm run validate:translations`


------
https://chatgpt.com/codex/tasks/task_e_68de7f6aab948325af00faa8aa40e436