### PR TITLE
Refactor devlog data for edge runtime

### DIFF
--- a/app/(marketing)/devlog/[slug]/page.tsx
+++ b/app/(marketing)/devlog/[slug]/page.tsx
@@ -5,17 +5,13 @@ import SiteLayout from '../../../../components/SiteLayout';
 import { getDictionary } from '../../../../lib/i18n/dictionaries';
 import { resolveRequestLocale } from '../../../../lib/i18n/server-locale';
 import { createDevlogPostMetadata, createStaticPageMetadata } from '../../../../lib/seo';
-import { getDevlogSummaries, getDevlogPost } from '../../../../lib/devlog';
+import { getDevlogPost } from '../../../../lib/devlog';
 
-export const runtime = 'nodejs';
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
 
 type DevlogPostParams = { slug: string };
 type DevlogMetadataProps = { params: Promise<DevlogPostParams> };
-
-export async function generateStaticParams() {
-  const posts = await getDevlogSummaries();
-  return posts.map(post => ({ slug: post.slug }));
-}
 
 export async function generateMetadata({ params }: DevlogMetadataProps): Promise<Metadata> {
   const { slug } = await params;
@@ -62,9 +58,10 @@ export default async function DevlogPostPage({ params }: { params: Promise<Devlo
         <div className="mt-8 overflow-hidden rounded-3xl border border-white/10">
           <img src={resolvedPost.cover} alt={resolvedPost.title} className="h-full w-full object-cover" />
         </div>
-        <div className="devlog-content mt-10 space-y-6 text-base leading-relaxed">
-          {resolvedPost.content}
-        </div>
+        <div
+          className="devlog-content mt-10 space-y-6 text-base leading-relaxed"
+          dangerouslySetInnerHTML={{ __html: resolvedPost.content }}
+        />
       </article>
     </SiteLayout>
   );

--- a/app/(marketing)/devlog/page.tsx
+++ b/app/(marketing)/devlog/page.tsx
@@ -3,15 +3,11 @@ import Link from 'next/link';
 import SiteLayout from '../../../components/SiteLayout';
 import { getDictionary } from '../../../lib/i18n/dictionaries';
 import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
-import { locales } from '../../../lib/i18n/config';
 import { createStaticPageMetadata } from '../../../lib/seo';
 import { getDevlogSummaries } from '../../../lib/devlog';
 
-export const runtime = 'nodejs';
-
-export function generateStaticParams(): Record<string, never>[] {
-  return locales.map(() => ({}));
-}
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await resolveRequestLocale();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,8 @@ import { createStaticPageMetadata } from '../lib/seo';
 import { resolveRequestLocale } from '../lib/i18n/server-locale';
 import { getLatestDevlogSummaries } from '../lib/devlog';
 
-export const runtime = 'nodejs';
+export const runtime = 'edge';
+export const dynamic = 'force-dynamic';
 
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await resolveRequestLocale();

--- a/lib/devlog/generated.ts
+++ b/lib/devlog/generated.ts
@@ -1,0 +1,17 @@
+// Ez a fájl automatikusan generálódik a scripts/generate-devlog-manifest.mjs futtatásával.
+// NE szerkeszd kézzel, mert a következő generálás felülírja.
+
+export type DevlogEntrySource = {
+  slug: string;
+  source: string;
+};
+
+import devlog__2024_08_15_engine_updates from '../../content/devlog/2024-08-15-engine-updates.mdx?raw';
+import devlog__2024_09_05_combat_ai from '../../content/devlog/2024-09-05-combat-ai.mdx?raw';
+import devlog__2024_09_20_community_playtest from '../../content/devlog/2024-09-20-community-playtest.mdx?raw';
+
+export const devlogEntries: DevlogEntrySource[] = [
+  { slug: '2024-08-15-engine-updates', source: devlog__2024_08_15_engine_updates },
+  { slug: '2024-09-05-combat-ai', source: devlog__2024_09_05_combat_ai },
+  { slug: '2024-09-20-community-playtest', source: devlog__2024_09_20_community_playtest }
+];

--- a/lib/devlog/index.ts
+++ b/lib/devlog/index.ts
@@ -1,10 +1,10 @@
 'use server';
 
-import fs from 'fs/promises';
-import path from 'path';
 import matter from 'gray-matter';
-import { cache, type ReactElement } from 'react';
-import { compileMDX } from 'next-mdx-remote/rsc';
+import { remark } from 'remark';
+import remarkHtml from 'remark-html';
+import { cache } from 'react';
+import { devlogEntries } from './generated';
 
 export type DevlogPostFrontmatter = {
   title: string;
@@ -18,10 +18,8 @@ export type DevlogPostSummary = DevlogPostFrontmatter & {
 };
 
 export type DevlogPost = DevlogPostSummary & {
-  content: ReactElement;
+  content: string;
 };
-
-const DEVLOG_DIR = path.join(process.cwd(), 'content', 'devlog');
 
 function parseFrontmatter(frontmatter: Record<string, unknown>): DevlogPostFrontmatter {
   const { title, date, summary, cover } = frontmatter;
@@ -49,44 +47,28 @@ function parseFrontmatter(frontmatter: Record<string, unknown>): DevlogPostFront
   };
 }
 
-async function readDevlogDirectory(): Promise<string[]> {
-  try {
-    const entries = await fs.readdir(DEVLOG_DIR);
-    return entries.filter(entry => entry.endsWith('.mdx')).sort();
-  } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return [];
-    }
-    throw error;
-  }
-}
-
 export const getDevlogSummaries = cache(async (): Promise<DevlogPostSummary[]> => {
-  const files = await readDevlogDirectory();
-  const posts: DevlogPostSummary[] = [];
-
-  for (const file of files) {
-    const filePath = path.join(DEVLOG_DIR, file);
-    const source = await fs.readFile(filePath, 'utf8');
-    const { data } = matter(source);
+  const posts = devlogEntries.map(entry => {
+    const { data } = matter(entry.source);
     const parsed = parseFrontmatter(data as Record<string, unknown>);
-    const slug = file.replace(/\.mdx$/, '');
-    posts.push({ ...parsed, slug });
-  }
+    return { ...parsed, slug: entry.slug } satisfies DevlogPostSummary;
+  });
 
   posts.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
   return posts;
 });
 
 export const getDevlogPost = cache(async (slug: string): Promise<DevlogPost> => {
-  const filePath = path.join(DEVLOG_DIR, `${slug}.mdx`);
-  const source = await fs.readFile(filePath, 'utf8');
-  const { frontmatter, content } = await compileMDX<DevlogPostFrontmatter>({
-    source,
-    options: { parseFrontmatter: true }
-  });
-  const parsed = parseFrontmatter(frontmatter as Record<string, unknown>);
-  return { ...parsed, slug, content };
+  const entry = devlogEntries.find(item => item.slug === slug);
+
+  if (!entry) {
+    throw new Error(`A "${slug}" azonosítójú devlog bejegyzés nem található.`);
+  }
+
+  const { content, data } = matter(entry.source);
+  const parsed = parseFrontmatter(data as Record<string, unknown>);
+  const rendered = await remark().use(remarkHtml).process(content);
+  return { ...parsed, slug, content: rendered.toString().trim() };
 });
 
 export const getLatestDevlogSummaries = cache(async (limit: number): Promise<DevlogPostSummary[]> => {

--- a/mdx.d.ts
+++ b/mdx.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mdx?raw' {
+  const content: string;
+  export default content;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     output: 'standalone',
-    images: { unoptimized: true }
+    images: { unoptimized: true },
+    webpack: config => {
+        config.module.rules.push({
+            test: /\.mdx$/i,
+            resourceQuery: /raw/,
+            type: 'asset/source'
+        });
+        return config;
+    }
 };
 module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,10 @@
             "dependencies": {
                 "gray-matter": "^4.0.3",
                 "next": "^15.0.0",
-                "next-mdx-remote": "^5.0.0",
                 "react": "18.3.1",
-                "react-dom": "18.3.1"
+                "react-dom": "18.3.1",
+                "remark": "^15.0.1",
+                "remark-html": "^16.0.1"
             },
             "devDependencies": {
                 "@cloudflare/next-on-pages": "^1.13.16",
@@ -40,29 +41,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "js-tokens": "^4.0.0",
-                "picocolors": "^1.1.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@cloudflare/kv-asset-handler": {
@@ -1318,78 +1296,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@mdx-js/mdx": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.1.1.tgz",
-            "integrity": "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "@types/estree-jsx": "^1.0.0",
-                "@types/hast": "^3.0.0",
-                "@types/mdx": "^2.0.0",
-                "acorn": "^8.0.0",
-                "collapse-white-space": "^2.0.0",
-                "devlop": "^1.0.0",
-                "estree-util-is-identifier-name": "^3.0.0",
-                "estree-util-scope": "^1.0.0",
-                "estree-walker": "^3.0.0",
-                "hast-util-to-jsx-runtime": "^2.0.0",
-                "markdown-extensions": "^2.0.0",
-                "recma-build-jsx": "^1.0.0",
-                "recma-jsx": "^1.0.0",
-                "recma-stringify": "^1.0.0",
-                "rehype-recma": "^1.0.0",
-                "remark-mdx": "^3.0.0",
-                "remark-parse": "^11.0.0",
-                "remark-rehype": "^11.0.0",
-                "source-map": "^0.7.0",
-                "unified": "^11.0.0",
-                "unist-util-position-from-estree": "^2.0.0",
-                "unist-util-stringify-position": "^4.0.0",
-                "unist-util-visit": "^5.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/@mdx-js/mdx/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/@mdx-js/mdx/node_modules/source-map": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/@mdx-js/react": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
-            "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/mdx": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            },
-            "peerDependencies": {
-                "@types/react": ">=16",
-                "react": ">=16"
-            }
-        },
         "node_modules/@next/env": {
             "version": "15.5.2",
             "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.2.tgz",
@@ -1778,16 +1684,9 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "license": "MIT"
-        },
-        "node_modules/@types/estree-jsx": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
-            "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+            "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@types/estree": "*"
-            }
+            "peer": true
         },
         "node_modules/@types/hast": {
             "version": "3.0.4",
@@ -1815,12 +1714,6 @@
                 "@types/unist": "*"
             }
         },
-        "node_modules/@types/mdx": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.13.tgz",
-            "integrity": "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==",
-            "license": "MIT"
-        },
         "node_modules/@types/ms": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -1841,6 +1734,7 @@
             "version": "19.1.16",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.16.tgz",
             "integrity": "sha512-WBM/nDbEZmDUORKnh5i1bTnAz6vTohUf9b8esSMu+b24+srbaxa04UbJgWx78CVfNXA20sNu0odEIluZDFdCog==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.0.2"
@@ -3201,6 +3095,7 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -3218,15 +3113,6 @@
             "peer": true,
             "peerDependencies": {
                 "acorn": "^8"
-            }
-        },
-        "node_modules/acorn-jsx": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "license": "MIT",
-            "peerDependencies": {
-                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/acorn-walk": {
@@ -3349,15 +3235,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/astring": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
-            "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
-            "license": "MIT",
-            "bin": {
-                "astring": "bin/astring"
             }
         },
         "node_modules/async-listen": {
@@ -3736,16 +3613,6 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
-        "node_modules/character-reference-invalid": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
-            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/check-types": {
             "version": "11.2.3",
             "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
@@ -3806,16 +3673,6 @@
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/collapse-white-space": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
-            "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
         },
         "node_modules/color": {
             "version": "4.2.3",
@@ -3974,6 +3831,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/data-uri-to-buffer": {
@@ -4288,38 +4146,6 @@
             "dev": true,
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/esast-util-from-estree": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/esast-util-from-estree/-/esast-util-from-estree-2.0.0.tgz",
-            "integrity": "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree-jsx": "^1.0.0",
-                "devlop": "^1.0.0",
-                "estree-util-visit": "^2.0.0",
-                "unist-util-position-from-estree": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/esast-util-from-js": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/esast-util-from-js/-/esast-util-from-js-2.0.1.tgz",
-            "integrity": "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree-jsx": "^1.0.0",
-                "acorn": "^8.0.0",
-                "esast-util-from-estree": "^2.0.0",
-                "vfile-message": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
         },
         "node_modules/esbuild": {
             "version": "0.15.18",
@@ -4727,106 +4553,6 @@
             },
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/estree-util-attach-comments": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
-            "integrity": "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/estree-util-build-jsx": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/estree-util-build-jsx/-/estree-util-build-jsx-3.0.1.tgz",
-            "integrity": "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree-jsx": "^1.0.0",
-                "devlop": "^1.0.0",
-                "estree-util-is-identifier-name": "^3.0.0",
-                "estree-walker": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/estree-util-build-jsx/node_modules/estree-walker": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/estree-util-is-identifier-name": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
-            "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/estree-util-scope": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/estree-util-scope/-/estree-util-scope-1.0.0.tgz",
-            "integrity": "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "devlop": "^1.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/estree-util-to-js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/estree-util-to-js/-/estree-util-to-js-2.0.0.tgz",
-            "integrity": "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree-jsx": "^1.0.0",
-                "astring": "^1.8.0",
-                "source-map": "^0.7.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/estree-util-to-js/node_modules/source-map": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-            "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-            "license": "BSD-3-Clause",
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/estree-util-visit": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
-            "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree-jsx": "^1.0.0",
-                "@types/unist": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/estree-walker": {
@@ -5300,55 +5026,38 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/hast-util-to-estree": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
-            "integrity": "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==",
+        "node_modules/hast-util-sanitize": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+            "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "^1.0.0",
-                "@types/estree-jsx": "^1.0.0",
                 "@types/hast": "^3.0.0",
-                "comma-separated-tokens": "^2.0.0",
-                "devlop": "^1.0.0",
-                "estree-util-attach-comments": "^3.0.0",
-                "estree-util-is-identifier-name": "^3.0.0",
-                "hast-util-whitespace": "^3.0.0",
-                "mdast-util-mdx-expression": "^2.0.0",
-                "mdast-util-mdx-jsx": "^3.0.0",
-                "mdast-util-mdxjs-esm": "^2.0.0",
-                "property-information": "^7.0.0",
-                "space-separated-tokens": "^2.0.0",
-                "style-to-js": "^1.0.0",
-                "unist-util-position": "^5.0.0",
-                "zwitch": "^2.0.0"
+                "@ungap/structured-clone": "^1.0.0",
+                "unist-util-position": "^5.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/hast-util-to-jsx-runtime": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
-            "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+        "node_modules/hast-util-to-html": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+            "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "^1.0.0",
                 "@types/hast": "^3.0.0",
                 "@types/unist": "^3.0.0",
+                "ccount": "^2.0.0",
                 "comma-separated-tokens": "^2.0.0",
-                "devlop": "^1.0.0",
-                "estree-util-is-identifier-name": "^3.0.0",
                 "hast-util-whitespace": "^3.0.0",
-                "mdast-util-mdx-expression": "^2.0.0",
-                "mdast-util-mdx-jsx": "^3.0.0",
-                "mdast-util-mdxjs-esm": "^2.0.0",
+                "html-void-elements": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
                 "property-information": "^7.0.0",
                 "space-separated-tokens": "^2.0.0",
-                "style-to-js": "^1.0.0",
-                "unist-util-position": "^5.0.0",
-                "vfile-message": "^4.0.0"
+                "stringify-entities": "^4.0.0",
+                "zwitch": "^2.0.4"
             },
             "funding": {
                 "type": "opencollective",
@@ -5386,6 +5095,16 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/html-void-elements": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+            "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/htmlparser2": {
@@ -5499,12 +5218,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/inline-style-parser": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
-            "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
-            "license": "MIT"
-        },
         "node_modules/is": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/is/-/is-3.3.2.tgz",
@@ -5513,30 +5226,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/is-alphabetical": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
-            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/is-alphanumerical": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
-            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
-            "license": "MIT",
-            "dependencies": {
-                "is-alphabetical": "^2.0.0",
-                "is-decimal": "^2.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-arrayish": {
@@ -5601,16 +5290,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/is-decimal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
-            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
         "node_modules/is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -5651,16 +5330,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/is-hexadecimal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
-            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-node-process": {
@@ -5922,18 +5591,6 @@
             "license": "ISC",
             "peer": true
         },
-        "node_modules/markdown-extensions": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-2.0.0.tgz",
-            "integrity": "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=16"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/marked": {
             "version": "13.0.3",
             "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
@@ -5965,83 +5622,6 @@
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0",
                 "unist-util-stringify-position": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-mdx": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
-            "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
-            "license": "MIT",
-            "dependencies": {
-                "mdast-util-from-markdown": "^2.0.0",
-                "mdast-util-mdx-expression": "^2.0.0",
-                "mdast-util-mdx-jsx": "^3.0.0",
-                "mdast-util-mdxjs-esm": "^2.0.0",
-                "mdast-util-to-markdown": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-mdx-expression": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
-            "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree-jsx": "^1.0.0",
-                "@types/hast": "^3.0.0",
-                "@types/mdast": "^4.0.0",
-                "devlop": "^1.0.0",
-                "mdast-util-from-markdown": "^2.0.0",
-                "mdast-util-to-markdown": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-mdx-jsx": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
-            "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree-jsx": "^1.0.0",
-                "@types/hast": "^3.0.0",
-                "@types/mdast": "^4.0.0",
-                "@types/unist": "^3.0.0",
-                "ccount": "^2.0.0",
-                "devlop": "^1.1.0",
-                "mdast-util-from-markdown": "^2.0.0",
-                "mdast-util-to-markdown": "^2.0.0",
-                "parse-entities": "^4.0.0",
-                "stringify-entities": "^4.0.0",
-                "unist-util-stringify-position": "^4.0.0",
-                "vfile-message": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/mdast-util-mdxjs-esm": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
-            "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree-jsx": "^1.0.0",
-                "@types/hast": "^3.0.0",
-                "@types/mdast": "^4.0.0",
-                "devlop": "^1.0.0",
-                "mdast-util-from-markdown": "^2.0.0",
-                "mdast-util-to-markdown": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -6236,108 +5816,6 @@
                 "micromark-util-types": "^2.0.0"
             }
         },
-        "node_modules/micromark-extension-mdx-expression": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.1.tgz",
-            "integrity": "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "devlop": "^1.0.0",
-                "micromark-factory-mdx-expression": "^2.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-events-to-acorn": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-extension-mdx-jsx": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.2.tgz",
-            "integrity": "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "devlop": "^1.0.0",
-                "estree-util-is-identifier-name": "^3.0.0",
-                "micromark-factory-mdx-expression": "^2.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-events-to-acorn": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0",
-                "vfile-message": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-mdx-md": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
-            "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
-            "license": "MIT",
-            "dependencies": {
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-mdxjs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
-            "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn": "^8.0.0",
-                "acorn-jsx": "^5.0.0",
-                "micromark-extension-mdx-expression": "^3.0.0",
-                "micromark-extension-mdx-jsx": "^3.0.0",
-                "micromark-extension-mdx-md": "^2.0.0",
-                "micromark-extension-mdxjs-esm": "^3.0.0",
-                "micromark-util-combine-extensions": "^2.0.0",
-                "micromark-util-types": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/micromark-extension-mdxjs-esm": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
-            "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "devlop": "^1.0.0",
-                "micromark-core-commonmark": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-events-to-acorn": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0",
-                "unist-util-position-from-estree": "^2.0.0",
-                "vfile-message": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/micromark-factory-destination": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
@@ -6379,33 +5857,6 @@
                 "micromark-util-character": "^2.0.0",
                 "micromark-util-symbol": "^2.0.0",
                 "micromark-util-types": "^2.0.0"
-            }
-        },
-        "node_modules/micromark-factory-mdx-expression": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.3.tgz",
-            "integrity": "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "devlop": "^1.0.0",
-                "micromark-factory-space": "^2.0.0",
-                "micromark-util-character": "^2.0.0",
-                "micromark-util-events-to-acorn": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0",
-                "unist-util-position-from-estree": "^2.0.0",
-                "vfile-message": "^4.0.0"
             }
         },
         "node_modules/micromark-factory-space": {
@@ -6608,31 +6059,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/micromark-util-events-to-acorn": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.3.tgz",
-            "integrity": "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==",
-            "funding": [
-                {
-                    "type": "GitHub Sponsors",
-                    "url": "https://github.com/sponsors/unifiedjs"
-                },
-                {
-                    "type": "OpenCollective",
-                    "url": "https://opencollective.com/unified"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "@types/unist": "^3.0.0",
-                "devlop": "^1.0.0",
-                "estree-util-visit": "^2.0.0",
-                "micromark-util-symbol": "^2.0.0",
-                "micromark-util-types": "^2.0.0",
-                "vfile-message": "^4.0.0"
-            }
         },
         "node_modules/micromark-util-html-tag-name": {
             "version": "2.0.1",
@@ -7017,27 +6443,6 @@
                 }
             }
         },
-        "node_modules/next-mdx-remote": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-5.0.0.tgz",
-            "integrity": "sha512-RNNbqRpK9/dcIFZs/esQhuLA8jANqlH694yqoDBK8hkVdJUndzzGmnPHa2nyi90N4Z9VmzuSWNRpr5ItT3M7xQ==",
-            "license": "MPL-2.0",
-            "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@mdx-js/mdx": "^3.0.1",
-                "@mdx-js/react": "^3.0.1",
-                "unist-util-remove": "^3.1.0",
-                "vfile": "^6.0.1",
-                "vfile-matter": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=14",
-                "npm": ">=7"
-            },
-            "peerDependencies": {
-                "react": ">=16"
-            }
-        },
         "node_modules/next/node_modules/postcss": {
             "version": "8.4.31",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7338,31 +6743,6 @@
                 "js-yaml": "^4.1.0",
                 "shellac": "^0.8.0"
             }
-        },
-        "node_modules/parse-entities": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
-            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "character-entities-legacy": "^3.0.0",
-                "character-reference-invalid": "^2.0.0",
-                "decode-named-character-reference": "^1.0.0",
-                "is-alphanumerical": "^2.0.0",
-                "is-decimal": "^2.0.0",
-                "is-hexadecimal": "^2.0.0"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/parse-entities/node_modules/@types/unist": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-            "license": "MIT"
         },
         "node_modules/parse-ms": {
             "version": "2.1.0",
@@ -7947,73 +7327,6 @@
                 "node": ">=8.10.0"
             }
         },
-        "node_modules/recma-build-jsx": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
-            "integrity": "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "estree-util-build-jsx": "^3.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/recma-jsx": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/recma-jsx/-/recma-jsx-1.0.1.tgz",
-            "integrity": "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==",
-            "license": "MIT",
-            "dependencies": {
-                "acorn-jsx": "^5.0.0",
-                "estree-util-to-js": "^2.0.0",
-                "recma-parse": "^1.0.0",
-                "recma-stringify": "^1.0.0",
-                "unified": "^11.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            },
-            "peerDependencies": {
-                "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/recma-parse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/recma-parse/-/recma-parse-1.0.0.tgz",
-            "integrity": "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "esast-util-from-js": "^2.0.0",
-                "unified": "^11.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/recma-stringify": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/recma-stringify/-/recma-stringify-1.0.0.tgz",
-            "integrity": "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/estree": "^1.0.0",
-                "estree-util-to-js": "^2.0.0",
-                "unified": "^11.0.0",
-                "vfile": "^6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/reghex": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/reghex/-/reghex-1.0.2.tgz",
@@ -8021,29 +7334,33 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/rehype-recma": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
-            "integrity": "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==",
+        "node_modules/remark": {
+            "version": "15.0.1",
+            "resolved": "https://registry.npmjs.org/remark/-/remark-15.0.1.tgz",
+            "integrity": "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==",
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "^1.0.0",
-                "@types/hast": "^3.0.0",
-                "hast-util-to-estree": "^3.0.0"
+                "@types/mdast": "^4.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-stringify": "^11.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/remark-mdx": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
-            "integrity": "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==",
+        "node_modules/remark-html": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-16.0.1.tgz",
+            "integrity": "sha512-B9JqA5i0qZe0Nsf49q3OXyGvyXuZFDzAP2iOFLEumymuYJITVpiH1IgsTEwTpdptDmZlMDMWeDmSawdaJIGCXQ==",
             "license": "MIT",
             "dependencies": {
-                "mdast-util-mdx": "^3.0.0",
-                "micromark-extension-mdxjs": "^3.0.0"
+                "@types/mdast": "^4.0.0",
+                "hast-util-sanitize": "^5.0.0",
+                "hast-util-to-html": "^9.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -8066,17 +7383,15 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/remark-rehype": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
-            "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+        "node_modules/remark-stringify": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+            "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
             "license": "MIT",
             "dependencies": {
-                "@types/hast": "^3.0.0",
                 "@types/mdast": "^4.0.0",
-                "mdast-util-to-hast": "^13.0.0",
-                "unified": "^11.0.0",
-                "vfile": "^6.0.0"
+                "mdast-util-to-markdown": "^2.0.0",
+                "unified": "^11.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -8708,24 +8023,6 @@
                 }
             ],
             "license": "MIT"
-        },
-        "node_modules/style-to-js": {
-            "version": "1.1.17",
-            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
-            "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
-            "license": "MIT",
-            "dependencies": {
-                "style-to-object": "1.0.9"
-            }
-        },
-        "node_modules/style-to-object": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
-            "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
-            "license": "MIT",
-            "dependencies": {
-                "inline-style-parser": "0.2.4"
-            }
         },
         "node_modules/styled-jsx": {
             "version": "5.1.6",
@@ -9367,53 +8664,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/unist-util-position-from-estree": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
-            "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^3.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-remove": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-remove/-/unist-util-remove-3.1.1.tgz",
-            "integrity": "sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-is": "^5.0.0",
-                "unist-util-visit-parents": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-remove/node_modules/@types/unist": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-            "license": "MIT"
-        },
-        "node_modules/unist-util-remove/node_modules/unist-util-is": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-            "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
         "node_modules/unist-util-stringify-position": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
@@ -9443,39 +8693,6 @@
             }
         },
         "node_modules/unist-util-visit-parents": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz",
-            "integrity": "sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0",
-                "unist-util-is": "^5.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-visit-parents/node_modules/@types/unist": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
-            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-            "license": "MIT"
-        },
-        "node_modules/unist-util-visit-parents/node_modules/unist-util-is": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-            "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/unist": "^2.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/unist-util-visit/node_modules/unist-util-visit-parents": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
             "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
@@ -9656,20 +8873,6 @@
             "dependencies": {
                 "@types/unist": "^3.0.0",
                 "vfile-message": "^4.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            }
-        },
-        "node_modules/vfile-matter": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vfile-matter/-/vfile-matter-5.0.1.tgz",
-            "integrity": "sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==",
-            "license": "MIT",
-            "dependencies": {
-                "vfile": "^6.0.0",
-                "yaml": "^2.0.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -11085,6 +10288,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
             "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "scripts": {
         "generate:build-info": "node ./scripts/generate-build-info.mjs",
         "generate:static-icons": "tsx ./scripts/generate-static-icons.mjs",
+        "generate:devlog-manifest": "node ./scripts/generate-devlog-manifest.mjs",
         "validate:translations": "tsx ./scripts/validate-translations.ts",
         "validate:sitemap": "tsx ./scripts/validate-sitemap.ts",
         "check:a11y": "tsx ./scripts/run-a11y-check.ts",
         "check:links": "linkinator http://localhost:3000 --recurse --skip \"^mailto:\" --skip \"^tel:\" --timeout 10000",
-        "dev": "npm run generate:static-icons && npm run generate:build-info && next dev",
-        "build": "npm run generate:static-icons && npm run validate:translations && npm run generate:build-info && next build",
+        "dev": "npm run generate:static-icons && npm run generate:devlog-manifest && npm run generate:build-info && next dev",
+        "build": "npm run generate:static-icons && npm run validate:translations && npm run generate:devlog-manifest && npm run generate:build-info && next build",
         "postbuild": "node ./scripts/wayback-save.mjs",
         "start": "next start",
         "export:cf": "npx vercel build && node ./scripts/patch-vercel-output.mjs && npx @cloudflare/next-on-pages@1 --skip-build"
@@ -20,9 +21,10 @@
     "dependencies": {
         "gray-matter": "^4.0.3",
         "next": "^15.0.0",
-        "next-mdx-remote": "^5.0.0",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "remark": "^15.0.1",
+        "remark-html": "^16.0.1"
     },
     "devDependencies": {
         "@cloudflare/next-on-pages": "^1.13.16",

--- a/scripts/generate-devlog-manifest.mjs
+++ b/scripts/generate-devlog-manifest.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const repoRoot = path.resolve(process.cwd());
+const contentDir = path.join(repoRoot, 'content', 'devlog');
+const targetFile = path.join(repoRoot, 'lib', 'devlog', 'generated.ts');
+
+async function ensureDirectoryExists(filePath) {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+}
+
+function createIdentifier(filename) {
+  const base = filename.replace(/\.mdx$/i, '');
+  const cleaned = base.replace(/[^a-zA-Z0-9]+/g, '_');
+  const identifier = cleaned.replace(/^(\d)/, '_$1');
+  return `devlog_${identifier}`;
+}
+
+async function generate() {
+  const entries = await fs.readdir(contentDir).catch(error => {
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  });
+
+  const mdxFiles = entries.filter(entry => entry.endsWith('.mdx')).sort();
+
+  const imports = [];
+  const mapping = [];
+
+  for (const file of mdxFiles) {
+    const identifier = createIdentifier(file);
+    const relativePath = `../../content/devlog/${file}?raw`;
+    imports.push(`import ${identifier} from '${relativePath}';`);
+    const slug = file.replace(/\.mdx$/i, '');
+    mapping.push(`  { slug: '${slug}', source: ${identifier} }`);
+  }
+
+  const fileContents = `// Ez a fájl automatikusan generálódik a scripts/generate-devlog-manifest.mjs futtatásával.
+// NE szerkeszd kézzel, mert a következő generálás felülírja.
+
+export type DevlogEntrySource = {
+  slug: string;
+  source: string;
+};
+
+${imports.join('\n')}
+
+export const devlogEntries: DevlogEntrySource[] = [
+${mapping.join(',\n')}
+];
+`;
+
+  await ensureDirectoryExists(targetFile);
+  await fs.writeFile(targetFile, fileContents, 'utf8');
+}
+
+generate().catch(error => {
+  console.error('[generate-devlog-manifest] Hiba történt:', error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- switch the home and devlog routes to the edge runtime while keeping them dynamic for locale resolution
- replace filesystem-based devlog loading with a generated manifest that inlines the MDX sources and renders them to HTML through remark
- add a build script, type declarations, and webpack configuration to import MDX files as raw strings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df6f6513d483259ecde838c4a999d4