### PR TITLE
Update header navigation and footer links

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -64,16 +64,11 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
   const navItems = useMemo(
     () =>
       [
+        dictionary.nav.world,
         dictionary.nav.modes,
-        dictionary.nav.modesPage,
         dictionary.nav.progression,
-        dictionary.nav.characters,
-        dictionary.nav.media,
-        dictionary.nav.roadmap,
         dictionary.nav.devlog,
-        dictionary.nav.community,
-        dictionary.nav.faq,
-        dictionary.nav.presskit
+        dictionary.nav.faq
       ],
     [dictionary.nav]
   );
@@ -94,6 +89,39 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
     return `${basePath}${href}`;
   };
 
+  const normalizePath = (value: string) => {
+    if (!value) {
+      return '/';
+    }
+
+    const withoutQuery = value.replace(/[?#].*$/, '');
+    if (!withoutQuery || withoutQuery === '') {
+      return '/';
+    }
+
+    if (withoutQuery === '/') {
+      return '/';
+    }
+
+    return withoutQuery.endsWith('/') ? withoutQuery.slice(0, -1) : withoutQuery;
+  };
+
+  const normalizedPathname = normalizePath(pathname);
+  const homePath = normalizePath(basePath || '/');
+
+  const isNavItemActive = (href: string) => {
+    if (href.startsWith('http://') || href.startsWith('https://')) {
+      return false;
+    }
+
+    if (href.startsWith('#')) {
+      return normalizedPathname === homePath;
+    }
+
+    const resolved = resolveHref(href);
+    return normalizePath(resolved) === normalizedPathname;
+  };
+
   return (
     <header
       className={`fixed inset-x-0 top-0 z-50 border-b border-white/10 backdrop-blur transition-colors ${
@@ -101,15 +129,30 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
       }`}
     >
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
-        <a href={basePath || '/'} className="font-semibold tracking-wide">
+        <a
+          href={basePath || '/'}
+          className="font-semibold tracking-wide focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+        >
           {dictionary.brand}
         </a>
         <nav className="hidden items-center gap-4 text-sm md:flex" aria-label={dictionary.navLabel}>
-          {navItems.map(item => (
-            <a key={item.label} href={resolveHref(item.href)} className="hover:opacity-80">
-              {item.label}
-            </a>
-          ))}
+          {navItems.map(item => {
+            const href = resolveHref(item.href);
+            const isActive = isNavItemActive(item.href);
+
+            return (
+              <a
+                key={item.label}
+                href={href}
+                aria-current={isActive ? 'page' : undefined}
+                className={`rounded-md px-2 py-1 transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black ${
+                  isActive ? 'bg-white/10 text-white' : 'text-white/80 hover:text-white'
+                }`}
+              >
+                {item.label}
+              </a>
+            );
+          })}
         </nav>
         <div className="flex items-center gap-2">
           <label className="sr-only" htmlFor="locale-switcher">
@@ -117,7 +160,7 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
           </label>
           <select
             id="locale-switcher"
-            className="rounded-md border border-white/20 bg-black/40 px-2 py-1 text-xs uppercase tracking-wide hover:border-white/40 focus:border-accentB focus:outline-none"
+            className="rounded-md border border-white/20 bg-black/40 px-2 py-1 text-xs uppercase tracking-wide hover:border-white/40 focus:border-accentB focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
             value={locale}
             onChange={event => handleLocaleChange(event.target.value as Locale)}
           >
@@ -130,14 +173,17 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
           <div className="hidden gap-2 sm:flex">
             {steamUrl && (
               <a
-                className="rounded-md bg-accentA px-3 py-1.5 text-sm font-semibold hover:opacity-90"
+                className="rounded-md bg-accentA px-3 py-1.5 text-sm font-semibold hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2 focus-visible:ring-offset-black"
                 href={steamUrl}
               >
                 {dictionary.wishlistCta}
               </a>
             )}
             {discordUrl && (
-              <a className="rounded-md bg-white/10 px-3 py-1.5 text-sm hover:bg-white/20" href={discordUrl}>
+              <a
+                className="rounded-md bg-white/10 px-3 py-1.5 text-sm transition hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                href={discordUrl}
+              >
                 {dictionary.discordCta}
               </a>
             )}

--- a/components/SiteLayout.tsx
+++ b/components/SiteLayout.tsx
@@ -14,6 +14,41 @@ type SiteLayoutProps = {
 
 export default function SiteLayout({ locale, dictionary, children }: SiteLayoutProps) {
   const basePath = locale === 'hu' ? '/hu' : '';
+  const resolvedSocialLinks = dictionary.footer.links.social
+    .map(link => {
+      const envValue = link.envKey ? serverEnv[link.envKey] : null;
+      const href = envValue ?? link.href ?? null;
+
+      if (!href) {
+        return null;
+      }
+
+      return {
+        label: link.label,
+        href
+      };
+    })
+    .filter((link): link is { label: string; href: string } => link !== null);
+
+  const resolveFooterHref = (path: string) => {
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+      return path;
+    }
+
+    if (path.startsWith('#')) {
+      return `${basePath}${path}`;
+    }
+
+    if (path === '/') {
+      return basePath || '/';
+    }
+
+    if (path.startsWith('/')) {
+      return `${basePath}${path}`;
+    }
+
+    return `${basePath}/${path}`;
+  };
 
   return (
     <>
@@ -26,14 +61,70 @@ export default function SiteLayout({ locale, dictionary, children }: SiteLayoutP
       <main className="pt-14">{children}</main>
       <footer className="mt-24 border-t border-white/10">
         <div className="mx-auto max-w-5xl px-4 py-12 text-sm">
-          <div className="grid gap-10 md:grid-cols-2">
+          <div className="grid gap-10 md:grid-cols-3">
+            <div>
+              <h2 className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                {dictionary.footer.links.navigationHeading}
+              </h2>
+              <nav className="mt-4 flex flex-col gap-2">
+                {dictionary.footer.links.navigation.map(link => {
+                  const href = resolveFooterHref(link.path);
+                  const isExternal = href.startsWith('http://') || href.startsWith('https://');
+
+                  if (isExternal) {
+                    return (
+                      <a
+                        key={link.path}
+                        href={href}
+                        className="opacity-80 transition hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                      >
+                        {link.label}
+                      </a>
+                    );
+                  }
+
+                  return (
+                    <Link
+                      key={link.path}
+                      href={href}
+                      className="opacity-80 transition hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                    >
+                      {link.label}
+                    </Link>
+                  );
+                })}
+              </nav>
+              {resolvedSocialLinks.length > 0 && (
+                <div className="mt-6">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-white/60">
+                    {dictionary.footer.links.socialHeading}
+                  </h3>
+                  <ul className="mt-4 flex flex-col gap-2">
+                    {resolvedSocialLinks.map(link => (
+                      <li key={link.label}>
+                        <a
+                          className="inline-flex items-center gap-2 opacity-80 transition hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                          href={link.href}
+                        >
+                          {link.label}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
             <div>
               <h2 className="text-xs font-semibold uppercase tracking-wide text-white/60">
                 {dictionary.footer.legalHeading}
               </h2>
               <nav className="mt-4 flex flex-col gap-2">
                 {dictionary.footer.legalLinks.map(link => (
-                  <Link key={link.path} href={`${basePath}${link.path}`} className="opacity-80 transition hover:opacity-100">
+                  <Link
+                    key={link.path}
+                    href={`${basePath}${link.path}`}
+                    className="opacity-80 transition hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                  >
                     {link.label}
                   </Link>
                 ))}
@@ -46,7 +137,10 @@ export default function SiteLayout({ locale, dictionary, children }: SiteLayoutP
               <div className="mt-4 space-y-3 opacity-80">
                 <p>
                   {dictionary.footer.contactEmailLabel}:{' '}
-                  <a className="underline transition hover:opacity-100" href={`mailto:${dictionary.footer.contactEmail}`}>
+                  <a
+                    className="underline transition hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+                    href={`mailto:${dictionary.footer.contactEmail}`}
+                  >
                     {dictionary.footer.contactEmail}
                   </a>
                 </p>

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -7,16 +7,11 @@ export const enDictionary: Dictionary = {
     brand: 'AIKA WORLD',
     navLabel: 'Primary navigation',
     nav: {
-      modes: { label: 'Modes', href: '#modes' },
-      characters: { label: 'Characters', href: '/characters' },
-      media: { label: 'Media', href: '#media' },
-      roadmap: { label: 'Roadmap', href: '#roadmap' },
+      world: { label: 'World', href: '/#world' },
+      modes: { label: 'Modes', href: '/modes' },
+      progression: { label: 'Progression', href: '/progression' },
       devlog: { label: 'Devlog', href: '/devlog' },
-      community: { label: 'Community', href: '#community' },
-      modesPage: { label: 'Detailed game modes', href: '/modes' },
-      progression: { label: 'Progression teaser', href: '/progression' },
-      faq: { label: 'FAQ', href: '/faq' },
-      presskit: { label: 'Presskit', href: '/presskit' }
+      faq: { label: 'FAQ', href: '/faq' }
     },
     wishlistCta: 'Wishlist on Steam',
     discordCta: 'Join Discord',
@@ -27,6 +22,21 @@ export const enDictionary: Dictionary = {
     }
   },
   footer: {
+    links: {
+      navigationHeading: 'Explore',
+      navigation: [
+        { path: '/#world', label: 'World' },
+        { path: '/modes', label: 'Modes' },
+        { path: '/progression', label: 'Progression' },
+        { path: '/devlog', label: 'Devlog' },
+        { path: '/faq', label: 'FAQ' }
+      ],
+      socialHeading: 'Community',
+      social: [
+        { label: 'Wishlist on Steam', envKey: 'steamUrl' },
+        { label: 'Join Discord', envKey: 'discordUrl' }
+      ]
+    },
     legalHeading: 'Legal',
     legalLinks: [
       { path: '/faq', label: 'FAQ' },

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -7,16 +7,11 @@ export const huDictionary: Dictionary = {
     brand: 'AIKA WORLD',
     navLabel: 'Fő navigáció',
     nav: {
-      modes: { label: 'Játékmódok', href: '#modes' },
-      characters: { label: 'Karakterek', href: '/characters' },
-      media: { label: 'Média', href: '#media' },
-      roadmap: { label: 'Roadmap', href: '#roadmap' },
-      devlog: { label: 'Devlog', href: '/hu/devlog' },
-      community: { label: 'Közösség', href: '#community' },
-      modesPage: { label: 'Részletes játékmódok', href: '/hu/modes' },
-      progression: { label: 'Fejlődés teaser', href: '/hu/progression' },
-      faq: { label: 'GYIK', href: '/hu/faq' },
-      presskit: { label: 'Presskit', href: '/hu/presskit' }
+      world: { label: 'Világ', href: '/#world' },
+      modes: { label: 'Játékmódok', href: '/modes' },
+      progression: { label: 'Fejlődés', href: '/progression' },
+      devlog: { label: 'Fejlesztői napló', href: '/devlog' },
+      faq: { label: 'GYIK', href: '/faq' }
     },
     wishlistCta: 'Wishlist a Steamen',
     discordCta: 'Csatlakozz Discordon',
@@ -27,6 +22,21 @@ export const huDictionary: Dictionary = {
     }
   },
   footer: {
+    links: {
+      navigationHeading: 'Fedezd fel',
+      navigation: [
+        { path: '/#world', label: 'Világ' },
+        { path: '/modes', label: 'Játékmódok' },
+        { path: '/progression', label: 'Fejlődés' },
+        { path: '/devlog', label: 'Fejlesztői napló' },
+        { path: '/faq', label: 'GYIK' }
+      ],
+      socialHeading: 'Közösség',
+      social: [
+        { label: 'Wishlist a Steamen', envKey: 'steamUrl' },
+        { label: 'Csatlakozz Discordon', envKey: 'discordUrl' }
+      ]
+    },
     legalHeading: 'Jogi információk',
     legalLinks: [
       { path: '/faq', label: 'GYIK' },

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -279,16 +279,11 @@ export type HeaderDictionary = {
   brand: string;
   navLabel: string;
   nav: {
+    world: HeaderNavItem;
     modes: HeaderNavItem;
-    characters: HeaderNavItem;
-    media: HeaderNavItem;
-    roadmap: HeaderNavItem;
-    devlog: HeaderNavItem;
-    community: HeaderNavItem;
-    modesPage: HeaderNavItem;
     progression: HeaderNavItem;
+    devlog: HeaderNavItem;
     faq: HeaderNavItem;
-    presskit: HeaderNavItem;
   };
   wishlistCta: string;
   discordCta: string;
@@ -301,7 +296,21 @@ export type FooterLinkDictionary = {
   label: string;
 };
 
+export type FooterExternalLinkDictionary = {
+  label: string;
+  href?: string;
+  envKey?: 'steamUrl' | 'discordUrl';
+};
+
+export type FooterLinksDictionary = {
+  navigationHeading: string;
+  navigation: FooterLinkDictionary[];
+  socialHeading: string;
+  social: FooterExternalLinkDictionary[];
+};
+
 export type FooterDictionary = {
+  links: FooterLinksDictionary;
   legalHeading: string;
   legalLinks: FooterLinkDictionary[];
   contactHeading: string;


### PR DESCRIPTION
## Summary
- reorder the header navigation to the new World → Modes → Progression → Devlog → FAQ set with aria-current handling and improved focus-visible styling
- extend the i18n dictionaries for header and footer, including duplicated navigation links plus community call-to-actions backed by environment URLs
- restructure the footer layout to surface the new navigation block and social links alongside the existing legal and contact sections

## Testing
- npm run validate:translations
- npm run build
- npm run check:a11y *(fails: Puppeteer missing system library libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68df73a8ed98832593245068c8e85a53