### PR TITLE
Add localized OG metadata assets for marketing pages

### DIFF
--- a/app/modes/page.tsx
+++ b/app/modes/page.tsx
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/modes', 'modes', {
-    ogImage: 'https://media.aikaworld.com/og-modes.jpg',
     ogAlt: dictionary.seo.pages.modes.ogAlt
   });
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,7 +14,6 @@ export async function generateMetadata(): Promise<Metadata> {
   const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   return createStaticPageMetadata(locale, dictionary, '/', 'home', {
-    ogImage: 'https://media.aikaworld.com/og-default.png',
     ogAlt: dictionary.seo.pages.home.ogAlt
   });
 }

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -684,7 +684,8 @@ export const enDictionary: Dictionary = {
       },
       characters: {
         title: 'Resonators – AIKA World',
-        description: 'Detailed profiles for Akari, Komi, Yui, Hina and Miyu from the world of AIKA.'
+        description: 'Detailed profiles for Akari, Komi, Yui, Hina and Miyu from the world of AIKA.',
+        ogAlt: 'AIKA World Resonators lineup artwork'
       },
       character: {
         description: character =>
@@ -694,7 +695,8 @@ export const enDictionary: Dictionary = {
       },
       presskit: {
         title: 'AIKA World – Presskit',
-        description: 'Downloadable logos, key art, screenshots and essential info for press.'
+        description: 'Downloadable logos, key art, screenshots and essential info for press.',
+        ogAlt: 'AIKA World presskit asset overview graphic'
       },
       faq: {
         title: 'FAQ – AIKA World',
@@ -703,11 +705,13 @@ export const enDictionary: Dictionary = {
       },
       privacy: {
         title: 'Privacy Policy – AIKA World',
-        description: 'Learn how we process cookies, analytics and contact data to keep the AIKA World community secure.'
+        description: 'Learn how we process cookies, analytics and contact data to keep the AIKA World community secure.',
+        ogAlt: 'AIKA World privacy policy illustration'
       },
       terms: {
         title: 'Terms of Use – AIKA World',
-        description: 'Understand the rules for using AIKA World IP, community spaces and downloadable assets.'
+        description: 'Understand the rules for using AIKA World IP, community spaces and downloadable assets.',
+        ogAlt: 'AIKA World terms of use illustration'
       },
       legalCopyright: {
         title: 'Copyright Policy / DMCA – AIKA World',
@@ -731,7 +735,8 @@ export const enDictionary: Dictionary = {
       },
       notFound: {
         title: 'Page not found – AIKA World',
-        description: 'The requested resonance is missing. Return to the homepage or browse characters.'
+        description: 'The requested resonance is missing. Return to the homepage or browse characters.',
+        ogAlt: 'AIKA World missing resonance illustration'
       }
     }
   }

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -688,7 +688,8 @@ export const huDictionary: Dictionary = {
       },
       characters: {
         title: 'Rezonátorok – AIKA World',
-        description: 'Akari, Komi, Yui, Hina és Miyu részletes karakterprofilja az AIKA World világából.'
+        description: 'Akari, Komi, Yui, Hina és Miyu részletes karakterprofilja az AIKA World világából.',
+        ogAlt: 'AIKA World rezonátor felállás grafika'
       },
       character: {
         description: character =>
@@ -698,7 +699,8 @@ export const huDictionary: Dictionary = {
       },
       presskit: {
         title: 'AIKA World – Presskit',
-        description: 'Letölthető logók, key artok, screenshotok és fontos információk az AIKA World sajtó számára.'
+        description: 'Letölthető logók, key artok, screenshotok és fontos információk az AIKA World sajtó számára.',
+        ogAlt: 'AIKA World sajtócsomag áttekintő grafika'
       },
       faq: {
         title: 'GYIK – AIKA World',
@@ -707,11 +709,13 @@ export const huDictionary: Dictionary = {
       },
       privacy: {
         title: 'Adatvédelmi tájékoztató – AIKA World',
-        description: 'Tudd meg, hogyan kezeljük a sütiket, az analitikát és a kapcsolati adatokat az AIKA Worldben.'
+        description: 'Tudd meg, hogyan kezeljük a sütiket, az analitikát és a kapcsolati adatokat az AIKA Worldben.',
+        ogAlt: 'AIKA World adatvédelmi illusztráció'
       },
       terms: {
         title: 'Felhasználási feltételek – AIKA World',
-        description: 'Ismerd meg az AIKA World IP használatának, közösségi részvételének és felelősségi szabályait.'
+        description: 'Ismerd meg az AIKA World IP használatának, közösségi részvételének és felelősségi szabályait.',
+        ogAlt: 'AIKA World felhasználási feltételek illusztráció'
       },
       legalCopyright: {
         title: 'Szerzői jog / DMCA – AIKA World',
@@ -735,7 +739,8 @@ export const huDictionary: Dictionary = {
       },
       notFound: {
         title: 'Oldal nem található – AIKA World',
-        description: 'A keresett rezgés hiányzik. Térj vissza a főoldalra vagy böngészd a karaktereket.'
+        description: 'A keresett rezgés hiányzik. Térj vissza a főoldalra vagy böngészd a karaktereket.',
+        ogAlt: 'AIKA World hiányzó rezonancia illusztráció'
       }
     }
   }

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -333,7 +333,7 @@ export type SeoDictionary = {
     progression: { title: string; description: string; ogAlt: string };
     playtests: { title: string; description: string; ogAlt: string };
     creatorProgram: { title: string; description: string; ogAlt: string };
-    characters: { title: string; description: string };
+    characters: { title: string; description: string; ogAlt: string };
     character: {
       description: (character: Character) => string;
       ogDescription: (character: Character) => string;
@@ -345,15 +345,15 @@ export type SeoDictionary = {
       description: (summary: string) => string;
       ogAlt: (postTitle: string) => string;
     };
-    presskit: { title: string; description: string };
+    presskit: { title: string; description: string; ogAlt: string };
     faq: { title: string; description: string; ogAlt: string };
-    privacy: { title: string; description: string };
-    terms: { title: string; description: string };
+    privacy: { title: string; description: string; ogAlt: string };
+    terms: { title: string; description: string; ogAlt: string };
     legalCopyright: { title: string; description: string; ogAlt: string };
     legalFanContent: { title: string; description: string; ogAlt: string };
     legalTrademark: { title: string; description: string; ogAlt: string };
     legalChangelog: { title: string; description: string; ogAlt: string };
-    notFound: { title: string; description: string };
+    notFound: { title: string; description: string; ogAlt: string };
   };
 };
 

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -21,6 +21,50 @@ const OG_IMAGE_VARIANTS = {
     en: '/og/aikaworld-default-en.svg',
     hu: '/og/aikaworld-default-hu.svg'
   },
+  home: {
+    en: '/og/aikaworld-home-en.svg',
+    hu: '/og/aikaworld-home-hu.svg'
+  },
+  modes: {
+    en: '/og/aikaworld-modes-en.svg',
+    hu: '/og/aikaworld-modes-hu.svg'
+  },
+  progression: {
+    en: '/og/aikaworld-progression-en.svg',
+    hu: '/og/aikaworld-progression-hu.svg'
+  },
+  playtests: {
+    en: '/og/aikaworld-playtests-en.svg',
+    hu: '/og/aikaworld-playtests-hu.svg'
+  },
+  creator: {
+    en: '/og/aikaworld-creator-en.svg',
+    hu: '/og/aikaworld-creator-hu.svg'
+  },
+  characters: {
+    en: '/og/aikaworld-characters-en.svg',
+    hu: '/og/aikaworld-characters-hu.svg'
+  },
+  devlog: {
+    en: '/og/aikaworld-devlog-en.svg',
+    hu: '/og/aikaworld-devlog-hu.svg'
+  },
+  faq: {
+    en: '/og/aikaworld-faq-en.svg',
+    hu: '/og/aikaworld-faq-hu.svg'
+  },
+  presskit: {
+    en: '/og/aikaworld-presskit-en.svg',
+    hu: '/og/aikaworld-presskit-hu.svg'
+  },
+  privacy: {
+    en: '/og/aikaworld-privacy-en.svg',
+    hu: '/og/aikaworld-privacy-hu.svg'
+  },
+  terms: {
+    en: '/og/aikaworld-terms-en.svg',
+    hu: '/og/aikaworld-terms-hu.svg'
+  },
   legal: {
     en: '/og/aikaworld-legal-en.svg',
     hu: '/og/aikaworld-legal-hu.svg'
@@ -28,6 +72,10 @@ const OG_IMAGE_VARIANTS = {
   changelog: {
     en: '/og/aikaworld-changelog-en.svg',
     hu: '/og/aikaworld-changelog-hu.svg'
+  },
+  notfound: {
+    en: '/og/aikaworld-notfound-en.svg',
+    hu: '/og/aikaworld-notfound-hu.svg'
   }
 } as const;
 
@@ -71,19 +119,28 @@ export function buildAlternates(path: string, currentLocale: Locale) {
 
 type StaticSeoPage = Exclude<keyof Dictionary['seo']['pages'], 'character' | 'devlogPost'>;
 
+const STATIC_PAGE_IMAGE_VARIANTS: Partial<Record<StaticSeoPage, OgImageVariant>> = {
+  home: 'home',
+  modes: 'modes',
+  progression: 'progression',
+  playtests: 'playtests',
+  creatorProgram: 'creator',
+  characters: 'characters',
+  devlog: 'devlog',
+  faq: 'faq',
+  presskit: 'presskit',
+  privacy: 'privacy',
+  terms: 'terms',
+  legalCopyright: 'legal',
+  legalFanContent: 'legal',
+  legalTrademark: 'legal',
+  legalChangelog: 'changelog',
+  notFound: 'notfound'
+};
+
 function resolveDefaultOgImage(page: StaticSeoPage, locale: Locale) {
-  switch (page) {
-    case 'privacy':
-    case 'terms':
-    case 'legalCopyright':
-    case 'legalFanContent':
-    case 'legalTrademark':
-      return resolveOgImage('legal', locale);
-    case 'legalChangelog':
-      return resolveOgImage('changelog', locale);
-    default:
-      return resolveOgImage('default', locale);
-  }
+  const variant = STATIC_PAGE_IMAGE_VARIANTS[page] ?? 'default';
+  return resolveOgImage(variant, locale);
 }
 
 export function createStaticPageMetadata(

--- a/public/og/aikaworld-characters-en.svg
+++ b/public/og/aikaworld-characters-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="characters-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f1c2a" />
+      <stop offset="100%" stop-color="#2a6fb9" />
+    </linearGradient>
+    <radialGradient id="characters-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#6bd8ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#6bd8ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#characters-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#characters-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Resonators</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Akari · Komi · Yui · Hina · Miyu</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Study roles, elements and squad synergies.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-characters-hu.svg
+++ b/public/og/aikaworld-characters-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="characters-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f1c2a" />
+      <stop offset="100%" stop-color="#2a6fb9" />
+    </linearGradient>
+    <radialGradient id="characters-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#6bd8ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#6bd8ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#characters-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#characters-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Rezonátorok</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Akari · Komi · Yui · Hina · Miyu</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Ismerd meg a szerepeket és az elemi szinergiákat.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-creator-en.svg
+++ b/public/og/aikaworld-creator-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="creator-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1032" />
+      <stop offset="100%" stop-color="#8654d6" />
+    </linearGradient>
+    <radialGradient id="creator-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#d7a6ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#d7a6ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#creator-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#creator-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Creator Program</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Briefings & capture kits</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Partner with the team and spotlight your community.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-creator-hu.svg
+++ b/public/og/aikaworld-creator-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="creator-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a1032" />
+      <stop offset="100%" stop-color="#8654d6" />
+    </linearGradient>
+    <radialGradient id="creator-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#d7a6ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#d7a6ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#creator-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#creator-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Kreator Program</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Briefingek & capture csomagok</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Dolgozz a csapattal és emeld ki a közösséged.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-devlog-en.svg
+++ b/public/og/aikaworld-devlog-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="devlog-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#101820" />
+      <stop offset="100%" stop-color="#3c4f75" />
+    </linearGradient>
+    <radialGradient id="devlog-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#9ec0ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#9ec0ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#devlog-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#devlog-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Devlog</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Build notes & art drops</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Track sprint updates straight from the studio.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-devlog-hu.svg
+++ b/public/og/aikaworld-devlog-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="devlog-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#101820" />
+      <stop offset="100%" stop-color="#3c4f75" />
+    </linearGradient>
+    <radialGradient id="devlog-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#9ec0ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#9ec0ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#devlog-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#devlog-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Fejlesztői napló</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Build jegyzetek & art dropok</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Kövesd a sprint frissítéseket közvetlenül a stúdióból.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-faq-en.svg
+++ b/public/og/aikaworld-faq-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="faq-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f2632" />
+      <stop offset="100%" stop-color="#2f9bbf" />
+    </linearGradient>
+    <radialGradient id="faq-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#7ff7ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#7ff7ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#faq-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#faq-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">FAQ</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Platforms, co-op, monetisation</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Get quick answers before diving into the world.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-faq-hu.svg
+++ b/public/og/aikaworld-faq-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="faq-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f2632" />
+      <stop offset="100%" stop-color="#2f9bbf" />
+    </linearGradient>
+    <radialGradient id="faq-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#7ff7ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#7ff7ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#faq-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#faq-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">GYIK</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Platformok, coop, monetizáció</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Kapj gyors válaszokat, mielőtt belépsz a világba.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-home-en.svg
+++ b/public/og/aikaworld-home-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="home-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a0f2a" />
+      <stop offset="100%" stop-color="#1d3d74" />
+    </linearGradient>
+    <radialGradient id="home-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#86d5ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#86d5ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#home-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#home-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">AIKA WORLD</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Anime co-op action RPG</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Squad up for raids, survival and lore drops.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-home-hu.svg
+++ b/public/og/aikaworld-home-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="home-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a0f2a" />
+      <stop offset="100%" stop-color="#1d3d74" />
+    </linearGradient>
+    <radialGradient id="home-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#86d5ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#86d5ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#home-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#home-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">AIKA WORLD</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Anime kooperatív akció RPG</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Alakíts csapatot rajtaütésekhez, túléléshez és történethez.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-modes-en.svg
+++ b/public/og/aikaworld-modes-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="modes-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1b0f3a" />
+      <stop offset="100%" stop-color="#433b9e" />
+    </linearGradient>
+    <radialGradient id="modes-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#ff9c47" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ff9c47" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#modes-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#modes-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Game Modes</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Raid Boss & Infest Survival</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Master mechanics, rotations and team roles.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-modes-hu.svg
+++ b/public/og/aikaworld-modes-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="modes-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1b0f3a" />
+      <stop offset="100%" stop-color="#433b9e" />
+    </linearGradient>
+    <radialGradient id="modes-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#ff9c47" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ff9c47" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#modes-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#modes-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Játékmódok</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Raid Boss & Infest Survival</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Tanuld meg a mechanikákat és a csapat szerepeit.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-notfound-en.svg
+++ b/public/og/aikaworld-notfound-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="notfound-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#080808" />
+      <stop offset="100%" stop-color="#333333" />
+    </linearGradient>
+    <radialGradient id="notfound-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#a0a0a0" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#a0a0a0" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#notfound-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#notfound-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">404</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Resonance not found</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Return to HQ or tune into another signal.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-notfound-hu.svg
+++ b/public/og/aikaworld-notfound-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="notfound-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#080808" />
+      <stop offset="100%" stop-color="#333333" />
+    </linearGradient>
+    <radialGradient id="notfound-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#a0a0a0" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#a0a0a0" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#notfound-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#notfound-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">404</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Rezonancia nem található</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Térj vissza a központba vagy keress más jelet.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-playtests-en.svg
+++ b/public/og/aikaworld-playtests-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="playtests-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2a0f18" />
+      <stop offset="100%" stop-color="#b1324a" />
+    </linearGradient>
+    <radialGradient id="playtests-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#ff6f8f" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ff6f8f" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#playtests-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#playtests-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Playtests</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Join upcoming waves</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Apply, share feedback and shape AIKA World.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-playtests-hu.svg
+++ b/public/og/aikaworld-playtests-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="playtests-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2a0f18" />
+      <stop offset="100%" stop-color="#b1324a" />
+    </linearGradient>
+    <radialGradient id="playtests-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#ff6f8f" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ff6f8f" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#playtests-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#playtests-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Playtesztek</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Csatlakozz a hullámokhoz</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Jelentkezz, adj visszajelzést, formáld az AIKA-t.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-presskit-en.svg
+++ b/public/og/aikaworld-presskit-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="presskit-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a151f" />
+      <stop offset="100%" stop-color="#7c2fa3" />
+    </linearGradient>
+    <radialGradient id="presskit-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#ffb7f4" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ffb7f4" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#presskit-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#presskit-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Presskit</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Logos, key art, screenshots</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Download ready-to-use media assets in minutes.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-presskit-hu.svg
+++ b/public/og/aikaworld-presskit-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="presskit-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a151f" />
+      <stop offset="100%" stop-color="#7c2fa3" />
+    </linearGradient>
+    <radialGradient id="presskit-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#ffb7f4" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ffb7f4" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#presskit-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#presskit-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Sajtócsomag</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Logók, key art, screenshotok</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Tölts le kész médiacsomagokat percek alatt.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-privacy-en.svg
+++ b/public/og/aikaworld-privacy-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="privacy-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#091c2a" />
+      <stop offset="100%" stop-color="#1b5d73" />
+    </linearGradient>
+    <radialGradient id="privacy-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#7de7ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#7de7ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#privacy-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#privacy-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Privacy Policy</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Data, cookies & security</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">See how we protect player information.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-privacy-hu.svg
+++ b/public/og/aikaworld-privacy-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="privacy-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#091c2a" />
+      <stop offset="100%" stop-color="#1b5d73" />
+    </linearGradient>
+    <radialGradient id="privacy-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#7de7ff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#7de7ff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#privacy-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#privacy-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Adatvédelmi szabályzat</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Adatok, sütik & biztonság</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Tudd meg, hogyan védjük a játékosokat.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-progression-en.svg
+++ b/public/og/aikaworld-progression-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="progression-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f2a1c" />
+      <stop offset="100%" stop-color="#2e7a63" />
+    </linearGradient>
+    <radialGradient id="progression-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#8cf3c5" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#8cf3c5" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#progression-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#progression-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Progression</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Resonance, gear, hub</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Unlock skills, craft builds and tune your hideout.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-progression-hu.svg
+++ b/public/og/aikaworld-progression-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="progression-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f2a1c" />
+      <stop offset="100%" stop-color="#2e7a63" />
+    </linearGradient>
+    <radialGradient id="progression-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#8cf3c5" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#8cf3c5" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#progression-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#progression-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Fejlődés</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Rezonancia, felszerelés, bázis</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Oldj fel képességeket és alakítsd a menedéket.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-terms-en.svg
+++ b/public/og/aikaworld-terms-en.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="terms-en-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#20130f" />
+      <stop offset="100%" stop-color="#a45b2d" />
+    </linearGradient>
+    <radialGradient id="terms-en-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#ffc48a" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ffc48a" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#terms-en-gradient)" />
+  <rect width="1200" height="630" fill="url(#terms-en-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Terms of Use</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Community & distribution rules</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Review the guidelines for using AIKA World.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>

--- a/public/og/aikaworld-terms-hu.svg
+++ b/public/og/aikaworld-terms-hu.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="terms-hu-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#20130f" />
+      <stop offset="100%" stop-color="#a45b2d" />
+    </linearGradient>
+    <radialGradient id="terms-hu-radial" cx="80%" cy="20%" r="70%">
+      <stop offset="0%" stop-color="#ffc48a" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ffc48a" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#terms-hu-gradient)" />
+  <rect width="1200" height="630" fill="url(#terms-hu-radial)" />
+  <g fill="rgba(255,255,255,0.12)">
+    <circle cx="1060" cy="120" r="110" />
+    <circle cx="980" cy="520" r="160" />
+  </g>
+  <g fill="#ffffff">
+    <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Felhasználási feltételek</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Közösségi & terjesztési szabályok</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Olvasd el az AIKA World használati irányait.</text>
+  </g>
+  <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
+    <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>
+    <text y="40" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="18" opacity="0.8">www.aikaworld.com</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add dedicated 1200×630 OG SVG variants for each marketing and legal page
- extend SEO helpers and dictionaries so every page exposes localized OG image selections and alt text
- update home and modes metadata to rely on the shared OG resolver instead of remote assets

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68df7773ef8c83258dfef1ae36a7f194