### PR TITLE
Javítás: Card komponens ReactElement típusai

### DIFF
--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { type ReactElement, type ReactNode } from 'react';
 
 function cn(...classes: Array<string | false | null | undefined>) {
   return classes.filter(Boolean).join(' ');
@@ -9,10 +9,10 @@ type CardRootProps = {
   className?: string;
 };
 
-type CardComponent = ((props: CardRootProps) => JSX.Element) & {
-  Title: (props: CardTitleProps) => JSX.Element;
-  Body: (props: CardBodyProps) => JSX.Element;
-  Actions: (props: CardActionsProps) => JSX.Element;
+type CardComponent = ((props: CardRootProps) => ReactElement) & {
+  Title: (props: CardTitleProps) => ReactElement;
+  Body: (props: CardBodyProps) => ReactElement;
+  Actions: (props: CardActionsProps) => ReactElement;
 };
 
 const Card = (({ children, className }: CardRootProps) => {


### PR DESCRIPTION
## Összegzés
- A Card komponens visszatérési típusait ReactElement-re állítottam át, így nincs szükség a globális JSX névtérre.

## Tesztek
- ⚠️ `npm run build` *(meghiúsult: a környezetben nem található az `@playwright/test` modul)*

------
https://chatgpt.com/codex/tasks/task_e_68df919a365483259c988c455748d2cf