### PR TITLE
Canon frakciónév frissítés és átirányítások

### DIFF
--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -61,7 +61,7 @@ export const enDictionary: Dictionary = {
       title: 'Co-op anime action RPG – Squad. Style. Progression.',
       highlight: 'Stylish Resonators, tactical synergy.',
       description:
-        'Five Resonators mastering raid arenas and survival waves together. A dark anime world with dynamic combat and deep progression systems built for long-term squad growth.',
+        'Five Resonators mastering raid arenas and survival waves together, drawing power from Pyro, Verdefa, Nerei, Aurelia and Nocturnis. A dark anime world with dynamic combat and deep progression systems built for long-term squad growth.',
       wishlistCta: 'Wishlist on Steam',
       discordCta: 'Join Discord',
       subscribeCta: 'Subscribe',
@@ -70,52 +70,52 @@ export const enDictionary: Dictionary = {
     world: {
       title: 'World & Factions',
       intro:
-        'Five rival power blocs shape the neon dusk of AIKA World. Align with the ideology that keeps your squad alive.',
+        'Five rival power blocs shape the neon dusk of AIKA World: Pyro, Verdefa, Nerei, Aurelia and Nocturnis. Align with the ideology that keeps your squad alive.',
       ctaLabel: 'Learn more',
       factions: [
         {
-          name: 'Emberforge Combine',
-          tagline: 'Industrial firebrands who temper the city in magma-fed forges.',
+          name: 'Pyro',
+          tagline: "Volcanic tacticians forging wargear beneath Vulkara's flame.",
           bullets: [
-            'Fire-reactor foundries forge modular weaponry overnight.',
-            'Logistics guilds keep squads stocked with incendiary ordnance.',
-            'Engineers retrofit armor with heat-reactive plating.'
+            "Capital Vulkara's magma railways deliver modular artillery to frontline squads.",
+            'Thermal engineers tune resonance armor to vent Pyro pressure waves before raids.',
+            'Inferna brigades deploy ember shields that harden during coordinated overdrives.'
           ]
         },
         {
-          name: 'Verdant Circuit Assembly',
-          tagline: 'Druidatech innovators weaving nature-grown circuitry with ritual.',
+          name: 'Verdefa',
+          tagline: "Bio-arcane stewards weaving Sylvara's living circuitries.",
           bullets: [
-            'Biofiber drones scout rooftops while pollinating safe zones.',
-            'Healing greenhouses double as respawn sanctuaries for squads.',
-            'Councils broker truces through data-bloom ceremonies.'
+            "Sylvara's canopy servers map safe corridors and share live intel between cells.",
+            'Ritualists braid bio-circuit sigils that amplify restorative blooms mid-engagement.',
+            'Scout leagues grow root tunnels to bypass corporate blockades without detection.'
           ]
         },
         {
-          name: 'Abyssal Veil Court',
-          tagline: 'Waterborne aristocracy ruling through shadowed etiquette.',
+          name: 'Nerei',
+          tagline: "Tidebound sovereigns enforcing Nerivia's abyssal edicts.",
           bullets: [
-            'Courtiers trade secrets via tide-locked encrypted mirrors.',
-            'Shadow entourages escort squads through submerged backstreets.',
-            'Oaths signed in abyssal ink carry lethal enforcement.'
+            "Nerivia's tide-locked palaces encrypt diplomacy between strike teams and envoys.",
+            'Veilcouriers flood alleys with pressure domes to screen infiltration routes.',
+            'Abyssal oaths imprint resonance marks that trigger lethal countermeasures on traitors.'
           ]
         },
         {
-          name: 'Silver Vow Order',
-          tagline: 'Knightly guardians wielding relic lances and luminous shields.',
+          name: 'Aurelia',
+          tagline: "Radiant oathkeepers defending Auris' silver bastions.",
           bullets: [
-            'Paladin companies drill cooperative formations for raids.',
-            'Shield-chaplains sanctify gear against corruption pulses.',
-            'Pilgrimage supply lines secure safe corridors between hubs.'
+            'Auris keep-factories mint vow-sealed plate for squads rotating through the citadel.',
+            'Shield-chaplains anoint resonance gear with lumen wards before corruption surges.',
+            'Pilgrimage caravans chart protected corridors linking enclave sanctums.'
           ]
         },
         {
-          name: 'Neon Veil Collective',
-          tagline: 'Cyberpunk underground thriving in glitch-lit tunnels.',
+          name: 'Nocturnis',
+          tagline: "Umbral information brokers ruling Noxhaven's undercity.",
           bullets: [
-            'Signal jammers mask squads from corporate trackers.',
-            'Cybernetic medics patch wounds with improvised firmware.',
-            'Street alliances unlock black market upgrades between runs.'
+            'Noxhaven vaults hoard ghost archives that decode enemy targeting sweeps.',
+            'Cipher-runners seed blackout clouds to hide squad deployments in neon streets.',
+            'Augury cells trade resonance blueprints that unlock clandestine upgrades between runs.'
           ]
         }
       ]
@@ -163,7 +163,8 @@ export const enDictionary: Dictionary = {
   },
   characters: {
     title: 'Resonators',
-      description: 'Pick your resonance. Each of the five girls excels at a different specialty.',
+    description:
+      'Find your resonance. Each of the five girls channels Pyro, Verdefa, Nerei, Aurelia or Nocturnis in a different way.',
       cards: [
         { slug: 'akari', name: 'Akari', role: 'Fire', color: 'accentA' },
         { slug: 'komi', name: 'Komi', role: 'Water', color: 'accentB' },
@@ -271,7 +272,7 @@ export const enDictionary: Dictionary = {
     navLabel: 'Section navigation',
     heading: 'AIKA World game modes',
     intro:
-      'Immerse yourself in co-op challenges: the Raid Boss Arena rewards precision, Infest Survival celebrates adaptive endurance, and Story Mode deepens narrative bonds. Use these guides to prepare your squad for every mode.',
+      'Immerse yourself in co-op challenges forged across Pyro, Verdefa, Nerei, Aurelia and Nocturnis: the Raid Boss Arena rewards precision, Infest Survival celebrates adaptive endurance, and Story Mode deepens narrative bonds. Use these guides to prepare your squad for every mode.',
     backToHome: 'Back to homepage',
     sections: [
       {
@@ -647,14 +648,16 @@ export const enDictionary: Dictionary = {
     contactSubject: '404 report – Missing AIKA World page'
   },
   seo: {
-    defaultTitle: 'AIKA World – Anime co-op action RPG',
-    defaultDescription: 'Co-op raid arenas, dark anime visuals and deep progression systems with five unique Resonators.',
+    defaultTitle: 'AIKA World – Pyro · Verdefa · Nerei · Aurelia · Nocturnis',
+    defaultDescription:
+      'Co-op raid arenas, dark anime visuals and deep progression systems featuring the factions of Pyro, Verdefa, Nerei, Aurelia and Nocturnis.',
     defaultOgAlt: 'AIKA World default share image',
     defaultLocale: 'en_US',
     pages: {
       home: {
-        title: 'AIKA World – Anime co-op action RPG',
-        description: 'Co-op raid arenas, dark fantasy factions and deep progression systems with five unique Resonators.',
+        title: 'AIKA World – Pyro · Verdefa · Nerei · Aurelia · Nocturnis',
+        description:
+          'Co-op raid arenas, dark fantasy factions and deep progression systems featuring Pyro, Verdefa, Nerei, Aurelia and Nocturnis.',
         ogAlt: 'AIKA World hero artwork'
       },
       modes: {

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -61,7 +61,7 @@ export const huDictionary: Dictionary = {
       title: 'Kooperatív anime akció RPG – Csapat. Látvány. Fejlődés.',
       highlight: 'Stílusos Rezonátorok, taktikus szinergiák.',
       description:
-        'Öt Rezonátor, akik együtt uralják a raid arénákat és túlélő hullámokat. Sötét anime világ, dinamikus kombók és mély fejlődési rendszerek a hosszú távú csapatépítéshez.',
+        'Öt Rezonátor, akik Pyro, Verdefa, Nerei, Aurelia és Nocturnis erejét használva együtt uralják a raid arénákat és túlélő hullámokat. Sötét anime világ, dinamikus kombók és mély fejlődési rendszerek a hosszú távú csapatépítéshez.',
       wishlistCta: 'Wishlist a Steamen',
       discordCta: 'Csatlakozz Discordon',
       subscribeCta: 'Feliratkozom',
@@ -70,52 +70,52 @@ export const huDictionary: Dictionary = {
     world: {
       title: 'Világ és frakciók',
       intro:
-        'Öt rivális hatalmi tömb uralja az AIKA World neon-alkonyát. Állj arra, amelyik életben tartja a csapatod.',
+        'Öt rivális hatalmi tömb uralja az AIKA World neon-alkonyát: Pyro, Verdefa, Nerei, Aurelia és Nocturnis. Állj arra, amelyik életben tartja a csapatod.',
       ctaLabel: 'Bővebben',
       factions: [
         {
-          name: 'Emberforge Combine',
-          tagline: 'Ipari lángharcosok, akik magma-táplált kohókban edzik a várost.',
+          name: 'Pyro',
+          tagline: 'Vulkara lángjára esküdött taktikus hadigépezet.',
           bullets: [
-            'Tűzreaktoros kohók egy éjszaka alatt moduláris fegyvereket öntenek.',
-            'Logisztikai céhek gondoskodnak az égő lőszerek folyamatos utánpótlásáról.',
-            'Mérnökeik hőre reagáló páncélrétegekkel szerelik fel a csapatokat.'
+            'Fővárosuk, Vulkara, lávahajtású sínpályákkal szórja szét a moduláris tüzérséget.',
+            'Termál mérnökök Pyro rezonanciáját vezetik el, hogy a páncél ne hevüljön túl a raid előtt.',
+            'Inferna századok izzáskupolái koordinált túlterheléseknél páncéllá keményednek.'
           ]
         },
         {
-          name: 'Verdant Circuit Assembly',
-          tagline: 'Druidatech újítók, akik természetben nőtt áramköröket fonnak rítusokkal.',
+          name: 'Verdefa',
+          tagline: 'Sylvara lombkatedrálisai között szőtt bio-rituális hálózat.',
           bullets: [
-            'Biofibrás drónjaik felderítik a tetőket és közben biztonságos zónákat poroznak be.',
-            'Gyógyító üvegházaik egyben respawn menedékek a csapatnak.',
-            'Tanácsaik adat-virágzás ceremóniákon közvetítenek fegyverszünetet.'
+            'Sylvara lombszerverei térképezik a biztonságos folyosókat és élő adatfolyamot küldenek a celláknak.',
+            'Rituálmesterek bioáramkör rúnákkal erősítik fel a gyógyító virágzást csata közben.',
+            'Felderítő ligák gyökéralagutakat nevelnek, hogy észrevétlenül kerüljék ki a blokádokat.'
           ]
         },
         {
-          name: 'Abyssal Veil Court',
-          tagline: 'Vízre épült arisztokrácia, akik árnyékos etikettel uralkodnak.',
+          name: 'Nerei',
+          tagline: 'Ár-apályra hangolt uralkodók Nerivia mélységi törvényeivel.',
           bullets: [
-            'Udvaroncok dagályra hangolt titkos tükrökön cserélik a bizalmas információkat.',
-            'Árnyékkíséreteik elárasztott sikátorokon vezetik át a csapatokat.',
-            'A mélységi tintával írt eskük halálos következményekkel járnak.'
+            'Nerivia árapály-zárt palotái titkosítják a rajtaütő csapatok diplomáciáját.',
+            'Fátyolfutárok nyomáskupolákkal árasztják el a sikátorokat, hogy fedezzék az infiltrációt.',
+            'A mélységi eskük rezonancia-jeleket égetnek a hűtlenekre, amelyek halálos ellenlépést indítanak.'
           ]
         },
         {
-          name: 'Silver Vow Order',
-          tagline: 'Lovagi őrség, relikvia-lándzsákkal és fénylő pajzsokkal.',
+          name: 'Aurelia',
+          tagline: 'Auris ezüst erődjeit őrző ragyogó esküvők.',
           bullets: [
-            'Paladin szakaszaik kooperatív formációkat gyakorolnak a raidhez.',
-            'Pajzskaplánjaik megszentelik a felszerelést a korrupciós hullámok ellen.',
-            'Zarándok szállítmányaik biztonságos folyosókat nyitnak a hubok között.'
+            'Auris kaszárnya-kohói esküvel lezárt páncélt adnak a citadellán átutazó rajoknak.',
+            'Pajzskaplánok fényvédelmet kennek a felszerelésre a korrupciós hullámok előtt.',
+            'Zarándok karavánok védett útvonalakat jelölnek ki a szentélyek között.'
           ]
         },
         {
-          name: 'Neon Veil Collective',
-          tagline: 'Cyberpunk földalatti hálózat, glitch-fényű alagutakban.',
+          name: 'Nocturnis',
+          tagline: 'Noxhaven árnyékpiacait uraló információs szindikátus.',
           bullets: [
-            'Jelzészavaróik elrejtik a csapatot a vállalati követők elől.',
-            'Kiborg medikusok rögtönzött firmware-rel foltozzák be a sebeket.',
-            'Utcai szövetségeik fekete piaci fejlesztéseket oldanak fel a menetek között.'
+            'Noxhaven széfjei szellemadat-archívumokat őriznek, amelyek visszafejtik az ellenséges célzást.',
+            'Kódfutárok áramszünet felhőket vetnek be, hogy eltakarják a csapatmozgást a neon utcákban.',
+            'Augur sejtjeik rezonancia-terveket cserélnek, amelyek titkos fejlesztéseket nyitnak meg a menetek között.'
           ]
         }
       ]
@@ -163,7 +163,8 @@ export const huDictionary: Dictionary = {
     },
     characters: {
       title: 'Rezonátorok',
-      description: 'Találd meg a rezonanciád. Az öt lány mind másban zseniális.',
+      description:
+        'Találd meg a rezonanciád. Az öt lány Pyro, Verdefa, Nerei, Aurelia vagy Nocturnis erejét csatornázza egyedi módon.',
       cards: [
         { slug: 'akari', name: 'Akari', role: 'Tűz', color: 'accentA' },
         { slug: 'komi', name: 'Komi', role: 'Víz', color: 'accentB' },
@@ -271,7 +272,7 @@ export const huDictionary: Dictionary = {
     navLabel: 'Szöveges horgonyok',
     heading: 'AIKA World játékmódok',
     intro:
-      'Merülj el a kooperatív kihívásokban: a Raid Boss Arena a precíz végrehajtást, az Infest Survival az adaptív túlélést jutalmazza, a Story Mode pedig mélyíti a narratívát és a karakterkapcsolatokat. Az alábbi útmutatók segítenek felkészülni mindegyik módra.',
+      'Merülj el Pyro, Verdefa, Nerei, Aurelia és Nocturnis kooperatív kihívásaiban: a Raid Boss Arena a precíz végrehajtást, az Infest Survival az adaptív túlélést jutalmazza, a Story Mode pedig mélyíti a narratívát és a karakterkapcsolatokat. Az alábbi útmutatók segítenek felkészülni mindegyik módra.',
     backToHome: 'Vissza a főoldalra',
     sections: [
       {
@@ -649,14 +650,16 @@ export const huDictionary: Dictionary = {
     contactSubject: '404 jelentés – Hiányzó AIKA World oldal'
   },
   seo: {
-    defaultTitle: 'AIKA World – Anime co-op action RPG',
-    defaultDescription: 'Kooperatív raid arénák, sötét anime látvány és mély fejlődési rendszerek öt egyedi Rezonátorral.',
+    defaultTitle: 'AIKA World – Pyro · Verdefa · Nerei · Aurelia · Nocturnis',
+    defaultDescription:
+      'Kooperatív raid arénák, sötét anime látvány és mély fejlődési rendszerek Pyro, Verdefa, Nerei, Aurelia és Nocturnis frakcióival.',
     defaultOgAlt: 'AIKA World alap megosztási kép',
     defaultLocale: 'hu_HU',
     pages: {
       home: {
-        title: 'AIKA World – Anime co-op action RPG',
-        description: 'Co-op raid arénák, sötét fantasy frakciók és mély fejlődési rendszerek öt egyedi Rezonátorral.',
+        title: 'AIKA World – Pyro · Verdefa · Nerei · Aurelia · Nocturnis',
+        description:
+          'Co-op raid arénák, sötét fantasy frakciók és mély fejlődési rendszerek Pyro, Verdefa, Nerei, Aurelia és Nocturnis erejével.',
         ogAlt: 'AIKA World hős grafika'
       },
       modes: {

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,20 @@
 /** @type {import('next').NextConfig} */
+const factionRedirects = [
+    { source: '/world/emberforge-combine', destination: '/world/pyro', permanent: true },
+    { source: '/world/verdant-circuit-assembly', destination: '/world/verdefa', permanent: true },
+    { source: '/world/abyssal-veil-court', destination: '/world/nerei', permanent: true },
+    { source: '/world/silver-vow-order', destination: '/world/aurelia', permanent: true },
+    { source: '/world/neon-veil-collective', destination: '/world/nocturnis', permanent: true },
+    { source: '/vilag/pyroszovetseg', destination: '/world/pyro', permanent: true },
+    { source: '/vilag/aurelia-rendje', destination: '/world/aurelia', permanent: true }
+];
+
 const nextConfig = {
     output: 'standalone',
     images: { unoptimized: true },
+    async redirects() {
+        return factionRedirects;
+    },
     webpack: config => {
         config.module.rules.push({
             test: /\.mdx$/i,


### PR DESCRIPTION
## Összegzés
- A Pyro, Verdefa, Nerei, Aurelia és Nocturnis canon neveket használtam az összes angol és magyar hero-, világ-, játékmód- és rezonátor-szekcióban, új magyar frakcióleírásokkal és a fővárosokkal.
- A meta title/description szövegeket mindkét nyelven frissítettem, hogy felsorolják az öt frakciót.
- 301-es átirányításokat állítottam be az összes korábbi frakció URL-ről az új canon útvonalakra.

## Tesztelés
- npm run validate:translations

------
https://chatgpt.com/codex/tasks/task_e_68dfc072924883259b51685d55161c35