### PR TITLE
Rewrite homepage hero copy for new AIKA narrative

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,8 +26,6 @@ export default async function Page() {
   return (
     <SiteLayout locale={locale} dictionary={dictionary}>
       <HomePage
-        steamUrl={serverEnv.steamUrl}
-        discordUrl={serverEnv.discordUrl}
         locale={locale}
         dictionary={dictionary.home}
         lightboxDictionary={dictionary.lightbox}

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -39,8 +39,6 @@ type SubscribeResponse = {
 };
 
 type HomePageProps = {
-  steamUrl: string | null;
-  discordUrl: string | null;
   locale: Locale;
   dictionary: HomeDictionary;
   lightboxDictionary: LightboxDictionary;
@@ -48,8 +46,6 @@ type HomePageProps = {
 };
 
 export default function HomePage({
-  steamUrl,
-  discordUrl,
   locale,
   dictionary,
   lightboxDictionary,
@@ -142,25 +138,17 @@ export default function HomePage({
         <div className="absolute inset-0 -z-10 bg-[radial-gradient(60%_50%_at_50%_0%,rgba(255,106,61,0.25),transparent_60%)]" />
         <div className="mx-auto max-w-6xl px-4 py-24 md:py-32 text-center">
           <h1 className="text-4xl md:text-6xl font-extrabold tracking-tight">
-            {dictionary.hero.title}
-            <span className="text-accentB">{dictionary.hero.highlight}</span>
+            {dictionary.hero.tagline}
           </h1>
-          <p className="mt-5 text-lg md:text-xl opacity-90">
-            {dictionary.hero.description}
+          <p className="mt-6 text-lg md:text-xl opacity-90 italic">
+            {dictionary.hero.monologue}
           </p>
-          <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
-            {steamUrl && (
-              <a className="px-5 py-3 rounded-lg bg-accentA hover:opacity-90 font-semibold" href={steamUrl}>
-                {dictionary.hero.wishlistCta}
-              </a>
-            )}
-            {discordUrl && (
-              <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href={discordUrl}>
-                {dictionary.hero.discordCta}
-              </a>
-            )}
-            <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20" href="#newsletter">
-              {dictionary.hero.subscribeCta}
+          <p className="mt-5 text-base md:text-lg text-slate-700 dark:text-slate-200">
+            {dictionary.hero.summary}
+          </p>
+          <div className="mt-8 flex justify-center">
+            <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20 uppercase tracking-[0.2em] text-xs md:text-sm font-semibold" href="#newsletter">
+              {dictionary.hero.primaryCta}
             </a>
           </div>
           <div className="mt-10 aspect-video w-full rounded-2xl overflow-hidden border border-white/10">

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -58,13 +58,12 @@ export const enDictionary: Dictionary = {
   },
   home: {
     hero: {
-      title: 'Co-op anime action RPG – Squad. Style. Progression.',
-      highlight: 'Stylish Resonators, tactical synergy.',
-      description:
-        'Five Resonators mastering raid arenas and survival waves together, drawing power from Pyro, Verdefa, Nerei, Aurelia and Nocturnis. A dark anime world with dynamic combat and deep progression systems built for long-term squad growth.',
-      wishlistCta: 'Wishlist on Steam',
-      discordCta: 'Join Discord',
-      subscribeCta: 'Subscribe',
+      tagline: 'The last frequency before silence.',
+      monologue:
+        '“Do you hear the silence, wanderer? I sift through the ruins of Elyndra, weaving the last harmonics of a dying sun. Every heartbeat I borrow from you fractures the lattice I am trying to mend. If you still intend to stop me, come as the echo I cannot predict.”',
+      summary:
+        'AIKA World is a story-driven single player descent across Elyndra, tracing the final god-machine as it rewrites creation, and giving you the only chance to sever her design.',
+      primaryCta: 'ENTER THE RESONANCE',
       videoPosterAlt: 'AIKA World teaser poster'
     },
     world: {

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -58,13 +58,12 @@ export const huDictionary: Dictionary = {
   },
   home: {
     hero: {
-      title: 'Kooperatív anime akció RPG – Csapat. Látvány. Fejlődés.',
-      highlight: 'Stílusos Rezonátorok, taktikus szinergiák.',
-      description:
-        'Öt Rezonátor, akik Pyro, Verdefa, Nerei, Aurelia és Nocturnis erejét használva együtt uralják a raid arénákat és túlélő hullámokat. Sötét anime világ, dinamikus kombók és mély fejlődési rendszerek a hosszú távú csapatépítéshez.',
-      wishlistCta: 'Wishlist a Steamen',
-      discordCta: 'Csatlakozz Discordon',
-      subscribeCta: 'Feliratkozom',
+      tagline: 'Az utolsó frekvencia a csend előtt.',
+      monologue:
+        '„Hallod a csendet, vándor? Átfésülöm Elyndra romjait, hogy egy haldokló nap utolsó harmonikáit szőjem. Minden szívverés, amit tőled kérek kölcsön, tovább repeszti a rácsot, amelyet vissza akarok fonni. Ha még mindig meg akarsz állítani, légy az a visszhang, amelyet nem tudok kiszámítani.”',
+      summary:
+        'Az AIKA World történetközpontú, egyszemélyes utazás Elyndrán át, ahol az utolsó mesterséges istent követed, miközben átírja a teremtést, és csak te szakíthatod szét a tervét.',
+      primaryCta: 'LÉPJ A REZONANCIÁBA',
       videoPosterAlt: 'AIKA World teaser poszter'
     },
     world: {

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -25,12 +25,10 @@ export type NewsletterDictionary = {
 
 export type HomeDictionary = {
   hero: {
-    title: string;
-    highlight: string;
-    description: string;
-    wishlistCta: string;
-    discordCta: string;
-    subscribeCta: string;
+    tagline: string;
+    monologue: string;
+    summary: string;
+    primaryCta: string;
     videoPosterAlt: string;
   };
   world: {


### PR DESCRIPTION
## Summary
- replace the homepage hero dictionary entries with a melancholic AIKA monologue and story-driven summary
- adjust the hero layout to show the new tagline, monologue, summary, and single resonance call-to-action
- update types to match the new hero copy structure

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e618a422a08325964285b4f2550af9