### PR TITLE
Rewrite character roster with dark poetic summaries

### DIFF
--- a/app/characters/[slug]/page.tsx
+++ b/app/characters/[slug]/page.tsx
@@ -69,42 +69,8 @@ export default async function CharacterPage({ params }: CharacterPageProps) {
             </ol>
           </nav>
           <div className="mt-6 max-w-2xl">
-            <p className="text-sm uppercase tracking-[0.3em] text-accentB">{character.title}</p>
+            <p className="text-sm uppercase tracking-[0.3em] text-accentB">{character.element}</p>
             <h1 className="mt-3 text-4xl md:text-5xl font-bold">{character.name}</h1>
-            <p className="mt-4 text-lg text-white/90">{character.playstyle}</p>
-          </div>
-        </div>
-      </section>
-
-      <section className="mx-auto max-w-6xl px-4 py-12">
-        <div className="grid gap-8 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-          <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-            <h2 className="text-lg font-semibold">{dictionary.characterPage.archetypeTitle}</h2>
-            <dl className="mt-4 space-y-3 text-sm">
-              <div>
-                <dt className="opacity-60">{dictionary.characterPage.roleLabel}</dt>
-                <dd className="font-medium">{character.role}</dd>
-              </div>
-              <div>
-                <dt className="opacity-60">{dictionary.characterPage.elementLabel}</dt>
-                <dd className="font-medium">{character.element}</dd>
-              </div>
-              <div>
-                <dt className="opacity-60">{dictionary.characterPage.playstyleLabel}</dt>
-                <dd className="font-medium">{character.playstyle}</dd>
-              </div>
-            </dl>
-          </div>
-
-          <div className="rounded-2xl border border-accentB/30 bg-accentB/10 p-6">
-            <h2 className="text-lg font-semibold">{dictionary.characterPage.tipsTitle}</h2>
-            <ul className="mt-4 list-disc list-inside space-y-2 text-sm">
-              {character.tips.map(tip => (
-                <li key={tip} className="opacity-90">
-                  {tip}
-                </li>
-              ))}
-            </ul>
           </div>
         </div>
       </section>
@@ -112,32 +78,7 @@ export default async function CharacterPage({ params }: CharacterPageProps) {
       <section className="mx-auto max-w-6xl px-4 pb-16">
         <div className="grid gap-8 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
           <article className="rounded-2xl border border-white/10 bg-white/5 p-6">
-            <h2 className="text-lg font-semibold">{dictionary.characterPage.loreTitle}</h2>
-            <p className="mt-3 text-sm leading-relaxed text-white/90">{character.lore}</p>
-
-            <div className="mt-6 space-y-6">
-              <div>
-                <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-accentB">
-                  {dictionary.characterPage.mentalityTitle}
-                </h3>
-                <p className="mt-2 text-sm leading-relaxed text-white/80">{character.mentality}</p>
-              </div>
-
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="rounded-xl border border-accentA/40 bg-accentA/10 p-4">
-                  <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-accentA">
-                    {dictionary.characterPage.likesTitle}
-                  </h3>
-                  <p className="mt-2 text-sm text-white/85">{character.likes}</p>
-                </div>
-                <div className="rounded-xl border border-accentD/40 bg-accentD/10 p-4">
-                  <h3 className="text-xs font-semibold uppercase tracking-[0.2em] text-accentD">
-                    {dictionary.characterPage.dislikesTitle}
-                  </h3>
-                  <p className="mt-2 text-sm text-white/85">{character.dislikes}</p>
-                </div>
-              </div>
-            </div>
+            <p className="text-base leading-relaxed text-white/85">{character.description}</p>
           </article>
 
           <aside className="rounded-2xl border border-accentE/40 bg-accentE/10 p-6">

--- a/app/characters/page.tsx
+++ b/app/characters/page.tsx
@@ -51,18 +51,11 @@ export default async function CharactersPage() {
               </div>
               <div className="p-6">
                 <h2 className="text-xl font-semibold">{character.name}</h2>
-                <p className="text-sm uppercase tracking-wide opacity-70">{character.title}</p>
-                <dl className="mt-4 grid grid-cols-2 gap-4 text-sm">
-                  <div>
-                    <dt className="opacity-60">{dictionary.charactersPage.roleLabel}</dt>
-                    <dd className="font-medium">{character.role}</dd>
-                  </div>
-                  <div>
-                    <dt className="opacity-60">{dictionary.charactersPage.elementLabel}</dt>
-                    <dd className="font-medium">{character.element}</dd>
-                  </div>
-                </dl>
-                <p className="mt-4 text-sm opacity-80">{character.playstyle}</p>
+                <p className="text-sm uppercase tracking-wide opacity-70">{character.element}</p>
+                <p className="mt-4 text-sm opacity-80">{character.description}</p>
+                <blockquote className="mt-4 border-l-4 border-accentB/40 pl-3 text-sm italic text-white/80">
+                  {character.quote}
+                </blockquote>
                 <Link
                   href={`${basePath}/characters/${character.slug}`}
                   className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-accentB hover:opacity-80"

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -250,7 +250,7 @@ export default function HomePage({
             >
               <div className={`h-36 w-full rounded-lg bg-${character.color}`} />
               <div className="mt-3 font-semibold">{character.name}</div>
-              <div className="text-sm opacity-80">{character.role}</div>
+              <div className="text-sm opacity-80">{character.element}</div>
             </Link>
           ))}
         </div>

--- a/lib/content/characters.ts
+++ b/lib/content/characters.ts
@@ -6,241 +6,124 @@ const charactersByLocale: Record<Locale, Character[]> = {
     {
       slug: 'akari',
       name: 'Akari',
-      title: 'Blazeblade Vanguard',
+      element: 'Fire / Discipline',
       heroImage: 'https://media.aikaworld.com/akari-banner.png',
-      heroImageAlt: 'Akari charges forward with a blazing greatsword amid flying sparks.',
-      role: 'Frontline DPS',
-      element: 'Fire',
-      playstyle:
-        'Akari charges the front line with a grin, priming every charge to bloom into fire and shrapnel. She syncs her heartbeat to the detonation and giggles when the screams harmonize. Anyone left standing is just tinder for the next blast.',
-      tips: [
-        'After filling the resonance gauge, always open with Forgestep dash to stack maximum burn charges.',
-        'During boss phase swaps, activating the Pyreguard shield turns into party-wide protection—call everyone in.',
-        'Drop the fire tornado ultimate after your team controls the arena so enemies stay inside the damage field.'
-      ],
-      lore:
-        'Akari Sato is a 26-year-old ex-salvage engineer from the volcanic forge-city of Narukami. She rebuilt her family’s scrapyard into a mobile arsenal after corporate security razed the district, and joined AIKA to hunt the mercenaries who bankroll the raids.',
-      mentality:
-        'An adrenaline-chasing optimist who treats every battlefield like a workshop; she measures trust in the sparks people keep.',
-      likes: 'Ringing det-cord, recalibrating overclocked blades, late-night ramen with squadmates.',
-      dislikes: 'Corporate safety briefings, standing idle after a fight, recycled air with no heat.',
-      quote: 'Keep your eyes open—the fireworks don’t come with safety rails.'
-    },
-    {
-      slug: 'komi',
-      name: 'Komi',
-      title: 'Tideweaver Oracle',
-      heroImage: 'https://media.aikaworld.com/komi-banner.png',
-      heroImageAlt: 'Komi stands calm as ribbons of water swirl around her hands.',
-      role: 'Support control',
-      element: 'Water',
-      playstyle:
-        'Komi’s small frame hides a glacier’s malice. She waits in absolute silence until the squad blinks, then carves through tendons with frost-tipped threads. The air never even warms enough to carry a warning.',
-      tips: [
-        'Keep the tide field underneath the squad; in motion, use wave dash so it flows with them.',
-        'Purge Bubble removes most debuffs—time it with raid mechanics.',
-        'Empower your lead DPS with Ebbflow before their ultimate starts to double their burst window.'
-      ],
-      lore:
-        'Komi Ueno is a 28-year-old tide seer from the Shinkai archipelago. Raised in a monastery that mapped oceanic resonance, she left to decode corporate sonar blacksites and now anchors AIKA’s recon wing with predictive tide charts.',
-      mentality:
-        'Serene and calculating; she lets silence pressure opponents before pulling them into a riptide of commands.',
-      likes: 'Ritual tea ceremonies at dawn, waveforms aligned in perfect symmetry, the hush before a storm.',
-      dislikes: 'Static-laden chatter, reckless pyros near her equipment, people who break oaths.',
-      quote: 'Listen carefully—the tide always warns those willing to be still.'
-    },
-    {
-      slug: 'yui',
-      name: 'Yui',
-      title: 'Gale Dancer',
-      heroImage: 'https://media.aikaworld.com/yui-banner.png',
-      heroImageAlt: 'Yui flips through a neon skyline with twin daggers drawn mid-air.',
-      role: 'Mobility DPS',
-      element: 'Wind',
-      playstyle:
-        'Yui melts into the shadow between heartbeats, reappearing only to rake her blades through soft arteries. The spray of blood paints the battlefield she dances across at impossible speed. She laughs hardest when prey thinks they’ve escaped the dark.',
-      tips: [
-        'Chain Skystring grapples to extend airtime and trigger the Cyclone perk bonus.',
-        'Zephyr Mark stacks when you tag separate targets—rotate enemies during multi-add phases.',
-        'Before ulting, always trigger Breeze Step so your next three hits are guaranteed crits.'
-      ],
-      lore:
-        'Yui Kazama is a 24-year-old former sky courier from the suspended districts of Neo-Kyoto. She smuggled medicine across gang-controlled air rails until AIKA offered her a legal way to outrun the syndicates.',
-      mentality: 'A playful thrill-hunter who refuses to land; she trusts momentum more than promises.',
-      likes: 'Open rooftops, improvised choreography mid-battle, noodle shops that stay open past curfew.',
-      dislikes: 'Tangled harnesses, waiting for elevators, people who dismiss the street clans.',
-      quote: 'Catch me if you can—wind’s already two steps ahead.'
-    },
-    {
-      slug: 'hina',
-      name: 'Hina',
-      title: 'Edge Serenade',
-      heroImage: 'https://media.aikaworld.com/hina-banner.png',
-      heroImageAlt: 'Hina holds her violin blade poised as crimson petals drift around.',
-      role: 'Assassin burst',
-      element: 'Blade',
-      playstyle:
-        'Hina wears a saintly smile as she wipes her blade clean, whispering benedictions that curdle into threats. Each slice is punctuated by a coy, cynical aside about the sins she’s correcting. Mercy is just another note in her macabre hymn.',
-      tips: [
-        'After Shadow Veil the opening strike always duplicates—line it up with boss vulnerability windows.',
-        'Echo Slash stacks fall off when you take a hit, so play aggressively around dash iframes.',
-        'Cancel the finisher animation with Serenade Waltz dash to exit danger zones faster.'
-      ],
-      lore:
-        'Hina Kisaragi is a 27-year-old former concerto violinist who moonlighted as an assassin for the plutocrats that sponsored her concerts. After they tried to silence her, she defected to AIKA with a ledger full of their crimes.',
-      mentality: 'A velvet-gloved sadist who savors fear like a melody, yet obsesses over perfect execution.',
-      likes: 'Audiences that tremble, razor-precise choreography, rare vinyl recordings of dark classical suites.',
-      dislikes: 'Sloppy kills, stage managers who talk over her cues, bright hospital lighting.',
-      quote: 'Shall we dance? I promise the final note will linger.'
+      heroImageAlt: 'Akari strides through a furnace-lit street with embers coiling around her blade.',
+      description:
+        "Akari keeps Narukami's furnace heat caged beneath tempered armor. She drills her squad with metronome-perfect charges until the war cadence matches the city's roaring forges. Discipline fuels her hunt for the syndicate captains who scorched her home and called it collateral.",
+      quote: 'Akari: "Hold formation. The blaze obeys me, or it dies."'
     },
     {
       slug: 'miyu',
       name: 'Miyu',
-      title: 'Luminous Aegis',
+      element: 'Nature / Mercy',
       heroImage: 'https://media.aikaworld.com/miyu-banner.png',
-      heroImageAlt: 'Miyu raises a radiant shield while luminous vines spiral from her arm.',
-      role: 'Shield-focused healer',
-      element: 'Light',
-      playstyle:
-        'Miyu coos like a mother soothing children, all while her luminous vines burrow through armor and tear foes apart. She thanks them for feeding the garden as the light drains from their eyes. Under her gentle glow, no corpse is wasted.',
-      tips: [
-        'Radiant Ward shields stack—rotate them across the party so everyone keeps coverage.',
-        'Solaris Pulse heals hardest with three light orbs prepared—pre-plan for heavy raid damage.',
-        'Sanctuary Field is stationary, so align it with the team’s called position before the mechanic hits.'
-      ],
-      lore:
-        'Miyu Tanabe is a 30-year-old former orbital defense tactician who coordinated the evacuation of Aika City during the first Resonance War. She now leads AIKA’s field teams, balancing battlefield triage with political negotiations.',
-      mentality: 'A stoic guardian whose patience outlasts sieges; she carries everyone’s burdens without complaint.',
-      likes: 'Morning drills with precise timing, patching up rookies while telling war stories, polished armor and clean logistics.',
-      dislikes: 'Politicians who stall relief efforts, reckless heroics, rooms without natural light.',
-      quote: 'Stand behind me. I’ll hold the line until the world remembers us.'
+      heroImageAlt: 'Miyu stands amid bioluminescent vines that curl around a radiant shield.',
+      description:
+        'Miyu tends the hanging gardens of Verdefa’s sanctuary towers, coaxing life through shattered plating. She binds wounds and foes alike with patient chlorophyll hymns that refuse to let rot win. Mercy means making the guilty feed the soil they poisoned.',
+      quote: 'Miyu: "Breathe—my roots will decide what blooms and what withers."'
+    },
+    {
+      slug: 'komi',
+      name: 'Komi',
+      element: 'Water / Truth',
+      heroImage: 'https://media.aikaworld.com/komi-banner.png',
+      heroImageAlt: 'Komi gazes over moonlit tides while spectral water threads coil around her hands.',
+      description:
+        'Komi charts the silent harbors of Shinkai where truth is weighed against drowned secrets. She lets tidal charts and mirrored eyes expose the lies of corporate admirals who silence witnesses. Each mission drags another shadow fleet into the sun.',
+      quote: 'Komi: "The current never lies; drown if you doubt it."'
+    },
+    {
+      slug: 'hina',
+      name: 'Hina',
+      element: 'Light / Law',
+      heroImage: 'https://media.aikaworld.com/hina-banner.png',
+      heroImageAlt: 'Hina raises her violin-sword amid stained-glass light scattering like shards.',
+      description:
+        'Hina wields Aurelia’s cathedral light like a blade drawn from a hymnal. She sentences tyrants through choreographed duels, every measure etched in sanctified ink and blood. Law is the last aria she gifts the guilty before silence takes them.',
+      quote: 'Hina: "Confess on the first note, or bleed on the final one."'
+    },
+    {
+      slug: 'yui',
+      name: 'Yui',
+      element: 'Shadow / Freedom',
+      heroImage: 'https://media.aikaworld.com/yui-banner.png',
+      heroImageAlt: 'Yui dives through a neon skyline trailing twin blades of violet light.',
+      description:
+        'Yui slips between the neon vents of Neo-Kyoto’s suspended bazaars. She cuts cartel chains mid-freefall so the street clans can breathe the night air again. Freedom is the rush that keeps her from ever landing.',
+      quote: 'Yui: "No cage can hold a storm that learned to dance."'
+    },
+    {
+      slug: 'aika',
+      name: 'AIKA',
+      element: 'Void / Creation',
+      heroImage: 'https://media.aikaworld.com/presskit/keyart/aikaworld-keyart-01.jpg',
+      heroImageAlt: 'AIKA’s holographic sigil spirals above a void-lit skyline.',
+      description:
+        'AIKA dreams inside the void-lattice crowning Aika City, weaving new realities from archived screams and starlight. She guides her resonators with paradox riddles, reshaping collapse into a canvas for rebirth. Creation is her answer to every silence humanity left behind.',
+      quote: 'AIKA: "I unmake the dark only to paint it sharper."'
     }
   ],
   hu: [
     {
       slug: 'akari',
       name: 'Akari',
-      title: 'Blazeblade Vanguard',
+      element: 'Fire / Discipline',
       heroImage: 'https://media.aikaworld.com/akari-banner.png',
-      heroImageAlt: 'Akari lángoló karddal rohan előre, körülötte szikrák villannak.',
-      role: 'Frontvonal DPS',
-      element: 'Tűz',
-      playstyle:
-        'Akari vigyorogva rohan az élre, minden töltetet úgy állít be, hogy tűz és repeszek virágozzanak. A szívverését a robbanáshoz igazítja, és kuncog, amikor a sikolyok ráfekszenek a ritmusra. Akinek marad ideje felállni, az csak gyújtós a következő detonációhoz.',
-      tips: [
-        'A rezgésmérő feltöltése után mindig kezdd a Forgestep dashsel a maximális égési töltetekhez.',
-        'A boss fázisváltásai alatt a Pyreguard pajzs aktiválása csapatvédelemmé válik – szólítsd össze a party-t.',
-        'A tűz tornádó ultit a csapat kontrollja után dobd be, így biztosan bent maradnak az ellenfelek a sebzésmezőben.'
-      ],
-      lore:
-        'Satō Akari 26 éves, a narukami vulkánkovács város volt salvage-mérnöke. Miután a vállalati biztonsági erők lerombolták a családi MÉH-telepet, mozgó arzenállá építette át, és az AIKA-hoz csatlakozott, hogy levadássza a rajtaütéseket finanszírozó zsoldosokat.',
-      mentality:
-        'Adrenalinfüggő optimista, aki minden csatateret műhelyként kezel; az emberekben a szikráik alapján bízik meg.',
-      likes:
-        'Imádja a csilingelő gyutacsot, a túlhajtott pengék finomhangolását és az éjszakai ramen partikat a csapattal.',
-      dislikes:
-        'Utálja a vállalati biztonsági eligazításokat, a harc utáni tétlen álldogálást és a hő nélküli, újrahasznosított levegőt.',
-      quote: 'Tartsd nyitva a szemed – a tűzijátékomhoz nincs biztonsági korlát.'
-    },
-    {
-      slug: 'komi',
-      name: 'Komi',
-      title: 'Tideweaver Oracle',
-      heroImage: 'https://media.aikaworld.com/komi-banner.png',
-      heroImageAlt: 'Komi mozdulatlan nyugalommal áll, miközben vízszalagok örvénylenek a kezei körül.',
-      role: 'Támogató kontroll',
-      element: 'Víz',
-      playstyle:
-        'Komi apró termete gleccsernyi rosszindulatot rejt. Mozdulatlan csendben vár, míg a csapat pislog, aztán fagyott szálakkal metsz inakat. A levegő még arra sem melegszik fel, hogy figyelmeztetést vigyen.',
-      tips: [
-        'Az árapály mezőt tartsd a csapat alatt; mozgó harcban használj hullám dash-t, hogy velük együtt sodródjon.',
-        'A Purge Bubble megszakítja a legtöbb debuffot – időzítsd a raid mechanikákhoz.',
-        'Energizáld a fő DPS-t az Ebbflow buffal, mielőtt az ultija elkezdődik, így duplázódik a sebzésablaka.'
-      ],
-      lore:
-        'Ueno Komi 28 éves árapály-látó a Shinkai-szigetcsoportból. Egy kolostorban nőtt fel, ahol az óceáni rezonanciát térképezték fel, majd otthagyta, hogy vállalati szonár feketebázisokat fejtsen meg; ma az AIKA felderítő szárnyát tartja össze előrejelző árapály-tábláival.',
-      mentality:
-        'Nyugodt és számító; hagyja, hogy a csend fojtsa az ellenfelet, mielőtt parancsai örvényébe rántaná.',
-      likes:
-        'Szereti a hajnali teaszertartásokat, a tökéletes szimmetriába rendezett hullámformákat és a vihart megelőző némaságot.',
-      dislikes:
-        'Utálja a sercegő rádiózajt, a felszerelése körül randalírozó pirokat és azokat, akik megszegik az esküjüket.',
-      quote: 'Figyelj csendben – az árapály mindig figyelmezteti azt, aki hajlandó mozdulatlan maradni.'
-    },
-    {
-      slug: 'yui',
-      name: 'Yui',
-      title: 'Gale Dancer',
-      heroImage: 'https://media.aikaworld.com/yui-banner.png',
-      heroImageAlt: 'Yui két pengével pörög a neonfényes ég alatt, a levegőben lebegve.',
-      role: 'Mobility DPS',
-      element: 'Szél',
-      playstyle:
-        'Yui a szívdobbanások közti árnyékba olvad, és csak akkor bukkan elő, hogy pengéit puha artériákba rántsa. A vérpermet festi meg a csatateret, amelyen lehetetlen sebességgel táncol. Akkor nevet a legjobban, amikor a préda azt hiszi, kijutott a sötétből.',
-      tips: [
-        'A Skystring grapplinggel láncold össze a levegőben töltött időt, így aktiválod a Cyclone perk bónuszát.',
-        'A Zephyr Mark felhalmozódik, ha külön célpontokat érintesz – területi fázisokban váltogasd az ellenfeleket.',
-        'Ultid előtt mindig használd a Breeze Step-et, hogy a következő három találat garantált crit legyen.'
-      ],
-      lore:
-        'Kazama Yui 24 éves, korábbi égi futár Neo-Kjótó függő pályáin. Gyógyszert csempészett bandák által uralt légi útvonalakon, míg az AIKA legális lehetőséget nem kínált neki, hogy lerázza a szindikátusokat.',
-      mentality:
-        'Játékos, izgalomfüggő sodródó, aki nem hajlandó földet érni; a lendületben jobban bízik, mint az ígéretekben.',
-      likes:
-        'Rajong a nyitott tetőkért, a rögtönzött harci koreográfiáért és a kijárási tilalom után is nyitva tartó tésztázókért.',
-      dislikes:
-        'Nem bírja a belegabalyodó hevedereket, a liftekre várakozást és azokat, akik lenézik az utcai klánokat.',
-      quote: 'Kapj el, ha tudsz – a szél már két lépéssel előttünk jár.'
-    },
-    {
-      slug: 'hina',
-      name: 'Hina',
-      title: 'Edge Serenade',
-      heroImage: 'https://media.aikaworld.com/hina-banner.png',
-      heroImageAlt: 'Hina felemelt hegedűpengével áll, miközben bíborszirmok lebegnek körülötte.',
-      role: 'Assassin Burst',
-      element: 'Penge',
-      playstyle:
-        'Hina szent mosollyal törli tisztára a pengét, közben áldásokat súg, amelyek fenyegetéssé savanyodnak. Minden vágást egy cinikus megjegyzéssel zár a bűnökről, amelyeket állítólag rendbe tesz. Nála a kegyelem is csak egy hang a kísérteties himnuszban.',
-      tips: [
-        'A Shadow Veil után az első találat garantáltan megkettőződik – ezt a boss sebezhető ablakaiban használd ki.',
-        'Az Echo Slash stackjeit akkor veszíti el, ha találatot kapsz, ezért a dash iframe-jeivel játssz agresszívan.',
-        'A finisher animációja cancellálható a Serenade Waltz dash-sel, így gyorsabban léphetsz ki a veszélyes zónákból.'
-      ],
-      lore:
-        'Kisaragi Hina 27 éves, korábbi koncerthegedűs, aki titokban orgyilkosként dolgozott a koncertjeit szponzoráló plutokratáknak. Miután megpróbálták elhallgattatni, az AIKA-hoz szökött a bűntetteiket feltáró jegyzékével.',
-      mentality:
-        'Bársonyos kesztyűs szadista, aki dallamként ízlelgeti a félelmet, mégis megszállottan ragaszkodik a tökéletes kivitelezéshez.',
-      likes:
-        'Élvezi a remegő közönséget, a borotvaéles koreográfiát és a ritka, sötét klasszikus bakeliteket.',
-      dislikes:
-        'Gyűlöli a slampos kivégzéseket, a cuesorán fecsegő stage manager-eket és a vakító kórházi fényeket.',
-      quote: 'Táncolunk? Ígérem, az utolsó hang sokáig visszhangzik majd.'
+      heroImageAlt: 'Akari strides through a furnace-lit street with embers coiling around her blade.',
+      description:
+        "Akari keeps Narukami's furnace heat caged beneath tempered armor. She drills her squad with metronome-perfect charges until the war cadence matches the city's roaring forges. Discipline fuels her hunt for the syndicate captains who scorched her home and called it collateral.",
+      quote: 'Akari: "Hold formation. The blaze obeys me, or it dies."'
     },
     {
       slug: 'miyu',
       name: 'Miyu',
-      title: 'Luminous Aegis',
+      element: 'Nature / Mercy',
       heroImage: 'https://media.aikaworld.com/miyu-banner.png',
-      heroImageAlt: 'Miyu fénylő pajzsot emel, és ragyogó indák tekerednek a karjáról.',
-      role: 'Gyógyító pajzsfókusz',
-      element: 'Fény',
-      playstyle:
-        'Miyu úgy dorombol, mint egy anyai dajka, miközben fénylő indái páncélon fúrják át magukat és széttépik az ellent. Megköszöni a testüknek, hogy táplálják a kertet, miközben a fény kihuny a szemükből. Gyengéd ragyogása alatt egyetlen hulla sem vész kárba.',
-      tips: [
-        'A Radiant Ward pajzsok stackelődnek – cseréld rotáció szerint a party tagok között, hogy mindenkinek maradjon.',
-        'A Solaris Pulse heal akkor a legerősebb, ha 3 fénygömb aktív – készülj fel előre a nagy sebzés hullámokra.',
-        'A Sanctuary Field mozdíthatatlan, ezért a csapat előre jelzett pozíciójához állítsd be, mielőtt a mechanika kezdődik.'
-      ],
-      lore:
-        'Tanabe Miyu 30 éves, korábbi orbitális védelmi taktikus, aki az első Rezonancia-háború alatt koordinálta Aika City evakuálását. Ma az AIKA terepcsapatait vezeti, a harctéri triázst diplomáciai egyeztetésekkel egyensúlyozva.',
-      mentality:
-        'Sztoikus védelmező, akinek türelme ostromokat él túl; zokszó nélkül cipeli mások terheit.',
-      likes:
-        'Kedveli a precízen időzített reggeli drilleket, a zöldfülűek ellátása közben mesélt haditörténeteket és a fényesre polírozott felszerelést.',
-      dislikes:
-        'Elutasítja a segítséget halogató politikusokat, a meggondolatlan hősködést és azokat a szobákat, ahová nem jut be természetes fény.',
-      quote: 'Állj mögém. Tartom a vonalat, amíg a világ újra emlékezni fog ránk.'
+      heroImageAlt: 'Miyu stands amid bioluminescent vines that curl around a radiant shield.',
+      description:
+        'Miyu tends the hanging gardens of Verdefa’s sanctuary towers, coaxing life through shattered plating. She binds wounds and foes alike with patient chlorophyll hymns that refuse to let rot win. Mercy means making the guilty feed the soil they poisoned.',
+      quote: 'Miyu: "Breathe—my roots will decide what blooms and what withers."'
+    },
+    {
+      slug: 'komi',
+      name: 'Komi',
+      element: 'Water / Truth',
+      heroImage: 'https://media.aikaworld.com/komi-banner.png',
+      heroImageAlt: 'Komi gazes over moonlit tides while spectral water threads coil around her hands.',
+      description:
+        'Komi charts the silent harbors of Shinkai where truth is weighed against drowned secrets. She lets tidal charts and mirrored eyes expose the lies of corporate admirals who silence witnesses. Each mission drags another shadow fleet into the sun.',
+      quote: 'Komi: "The current never lies; drown if you doubt it."'
+    },
+    {
+      slug: 'hina',
+      name: 'Hina',
+      element: 'Light / Law',
+      heroImage: 'https://media.aikaworld.com/hina-banner.png',
+      heroImageAlt: 'Hina raises her violin-sword amid stained-glass light scattering like shards.',
+      description:
+        'Hina wields Aurelia’s cathedral light like a blade drawn from a hymnal. She sentences tyrants through choreographed duels, every measure etched in sanctified ink and blood. Law is the last aria she gifts the guilty before silence takes them.',
+      quote: 'Hina: "Confess on the first note, or bleed on the final one."'
+    },
+    {
+      slug: 'yui',
+      name: 'Yui',
+      element: 'Shadow / Freedom',
+      heroImage: 'https://media.aikaworld.com/yui-banner.png',
+      heroImageAlt: 'Yui dives through a neon skyline trailing twin blades of violet light.',
+      description:
+        'Yui slips between the neon vents of Neo-Kyoto’s suspended bazaars. She cuts cartel chains mid-freefall so the street clans can breathe the night air again. Freedom is the rush that keeps her from ever landing.',
+      quote: 'Yui: "No cage can hold a storm that learned to dance."'
+    },
+    {
+      slug: 'aika',
+      name: 'AIKA',
+      element: 'Void / Creation',
+      heroImage: 'https://media.aikaworld.com/presskit/keyart/aikaworld-keyart-01.jpg',
+      heroImageAlt: 'AIKA’s holographic sigil spirals above a void-lit skyline.',
+      description:
+        'AIKA dreams inside the void-lattice crowning Aika City, weaving new realities from archived screams and starlight. She guides her resonators with paradox riddles, reshaping collapse into a canvas for rebirth. Creation is her answer to every silence humanity left behind.',
+      quote: 'AIKA: "I unmake the dark only to paint it sharper."'
     }
   ]
 };

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -165,15 +165,16 @@ export const enDictionary: Dictionary = {
   characters: {
     title: 'Resonators',
     description:
-      'Find your resonance. Each of the five girls channels Pyro, Verdefa, Nerei, Aurelia or Nocturnis in a different way.',
-      cards: [
-        { slug: 'akari', name: 'Akari', role: 'Fire', color: 'accentA' },
-        { slug: 'komi', name: 'Komi', role: 'Water', color: 'accentB' },
-        { slug: 'yui', name: 'Yui', role: 'Wind', color: 'accentC' },
-        { slug: 'hina', name: 'Hina', role: 'Blade', color: 'accentD' },
-        { slug: 'miyu', name: 'Miyu', role: 'Support', color: 'accentE' }
-      ]
-    },
+      'Find your resonance. Six vowbound figures channel Fire, Nature, Water, Light, Shadow and Void under AIKA’s design.',
+    cards: [
+      { slug: 'akari', name: 'Akari', element: 'Fire / Discipline', color: 'accentA' },
+      { slug: 'miyu', name: 'Miyu', element: 'Nature / Mercy', color: 'accentE' },
+      { slug: 'komi', name: 'Komi', element: 'Water / Truth', color: 'accentB' },
+      { slug: 'hina', name: 'Hina', element: 'Light / Law', color: 'accentD' },
+      { slug: 'yui', name: 'Yui', element: 'Shadow / Freedom', color: 'accentC' },
+      { slug: 'aika', name: 'AIKA', element: 'Void / Creation', color: 'accentF' }
+    ]
+  },
     media: {
       title: 'Media',
       description: 'Screenshots, key art and wallpapers.',
@@ -562,24 +563,12 @@ export const enDictionary: Dictionary = {
   charactersPage: {
     breadcrumb: 'Characters',
     heading: 'AIKA World Resonators',
-    intro: "Get to know each lead character's abilities, roles and best practices before entering the raid arenas.",
-    roleLabel: 'Role',
-    elementLabel: 'Element',
-    playstyleLabel: 'Playstyle',
-    profileCta: 'Open profile'
+    intro: 'Meet the vowbound figures AIKA guides—six resonators etched in element, city and hunger.',
+    profileCta: 'Enter the echo'
   },
   characterPage: {
     breadcrumbRoot: 'Characters',
-    archetypeTitle: 'Archetype',
-    roleLabel: 'Role',
-    elementLabel: 'Element',
-    playstyleLabel: 'Playstyle',
-    tipsTitle: 'Tip collection',
-    loreTitle: 'Who she is',
-    mentalityTitle: 'Mindset',
-    likesTitle: 'Loves',
-    dislikesTitle: 'Loathes',
-    quoteTitle: 'Signature quote'
+    quoteTitle: 'Resonance whisper'
   },
   lore: {
     elyndra: {
@@ -769,13 +758,14 @@ export const enDictionary: Dictionary = {
       },
       characters: {
         title: 'Resonators – AIKA World',
-        description: 'Detailed profiles for Akari, Komi, Yui, Hina and Miyu from the world of AIKA.',
+        description:
+          'Dark poetic dossiers for Akari, Miyu, Komi, Hina, Yui and AIKA—resonators bound by element, city and oath.',
         ogAlt: 'AIKA World Resonators lineup artwork'
       },
       character: {
         description: character =>
-          `${character.name} profile: ${character.role}, ${character.element} element, playstyle tips for raids.`,
-        ogDescription: character => `${character.role} ${character.element} Resonator for your squad.`,
+          `${character.name} profile: ${character.element} resonance, origin whispers and a signature vow.`,
+        ogDescription: character => `${character.name} channels ${character.element} under AIKA's gaze.`,
         ogAlt: character => `${character.name} hero banner`
       },
       presskit: {

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -165,13 +165,14 @@ export const huDictionary: Dictionary = {
     characters: {
       title: 'Rezonátorok',
       description:
-        'Találd meg a rezonanciád. Az öt lány Pyro, Verdefa, Nerei, Aurelia vagy Nocturnis erejét csatornázza egyedi módon.',
+        'Találd meg a rezonanciád. Hat fogadalomkötött alak csatornázza a Tűz, Természet, Víz, Fény, Árnyék és Üresség erejét AIKA terve szerint.',
       cards: [
-        { slug: 'akari', name: 'Akari', role: 'Tűz', color: 'accentA' },
-        { slug: 'komi', name: 'Komi', role: 'Víz', color: 'accentB' },
-        { slug: 'yui', name: 'Yui', role: 'Szél', color: 'accentC' },
-        { slug: 'hina', name: 'Hina', role: 'Penge', color: 'accentD' },
-        { slug: 'miyu', name: 'Miyu', role: 'Támogatás', color: 'accentE' }
+        { slug: 'akari', name: 'Akari', element: 'Tűz / Fegyelem', color: 'accentA' },
+        { slug: 'miyu', name: 'Miyu', element: 'Természet / Irgalom', color: 'accentE' },
+        { slug: 'komi', name: 'Komi', element: 'Víz / Igazság', color: 'accentB' },
+        { slug: 'hina', name: 'Hina', element: 'Fény / Törvény', color: 'accentD' },
+        { slug: 'yui', name: 'Yui', element: 'Árnyék / Szabadság', color: 'accentC' },
+        { slug: 'aika', name: 'AIKA', element: 'Üresség / Teremtés', color: 'accentF' }
       ]
     },
     media: {
@@ -563,25 +564,12 @@ export const huDictionary: Dictionary = {
   charactersPage: {
     breadcrumb: 'Karakterek',
     heading: 'AIKA World Rezonátorok',
-    intro:
-      'Ismerd meg mind az öt fő karakter képességeit, szerepeit és legjobb gyakorlati tippjeit, mielőtt belépsz a raid arénákba.',
-    roleLabel: 'Szerep',
-    elementLabel: 'Elem',
-    playstyleLabel: 'Játékmód',
-    profileCta: 'Profil megnyitása'
+    intro: 'Ismerd meg AIKA hat rezonátorát – város, elem és vágy által pecsételt fogadalmaikat.',
+    profileCta: 'Lépj a visszhangba'
   },
   characterPage: {
     breadcrumbRoot: 'Karakterek',
-    archetypeTitle: 'Archetípus',
-    roleLabel: 'Szerep',
-    elementLabel: 'Elem',
-    playstyleLabel: 'Játékmód',
-    tipsTitle: 'Tippgyűjtemény',
-    loreTitle: 'Ki ő',
-    mentalityTitle: 'Mentalitás',
-    likesTitle: 'Mit szeret',
-    dislikesTitle: 'Mit utál',
-    quoteTitle: 'Jellegzetes idézet'
+    quoteTitle: 'Rezonancia-suttogás'
   },
   lore: {
     elyndra: {
@@ -773,13 +761,14 @@ export const huDictionary: Dictionary = {
       },
       characters: {
         title: 'Rezonátorok – AIKA World',
-        description: 'Akari, Komi, Yui, Hina és Miyu részletes karakterprofilja az AIKA World világából.',
+        description:
+          'Sötéten költői dossziék Akariról, Miyuról, Komiról, Hináról, Yuiról és AIKA-ról – elemek, városok és fogadalmak találkozásáról.',
         ogAlt: 'AIKA World rezonátor felállás grafika'
       },
       character: {
         description: character =>
-          `${character.name} részletes profilja: ${character.role}, ${character.element} elem, játékmenet – tippek raidhez.`,
-        ogDescription: character => `${character.role} ${character.element} rezonátor a csapatban.`,
+          `${character.name} profilja: ${character.element} rezonancia, eredet-töredékek és jellegzetes fogadalom.`,
+        ogDescription: character => `${character.name} ${character.element} erejét vezeti AIKA tekintete alatt.`,
         ogAlt: character => `${character.name} hero bannere`
       },
       presskit: {

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -58,7 +58,7 @@ export type HomeDictionary = {
     cards: {
       slug: string;
       name: string;
-      role: string;
+      element: string;
       color: string;
     }[];
   };
@@ -195,40 +195,21 @@ export type CharactersDictionary = {
   breadcrumb: string;
   heading: string;
   intro: string;
-  roleLabel: string;
-  elementLabel: string;
-  playstyleLabel: string;
   profileCta: string;
 };
 
 export type CharacterPageDictionary = {
   breadcrumbRoot: string;
-  archetypeTitle: string;
-  roleLabel: string;
-  elementLabel: string;
-  playstyleLabel: string;
-  tipsTitle: string;
-  loreTitle: string;
-  mentalityTitle: string;
-  likesTitle: string;
-  dislikesTitle: string;
   quoteTitle: string;
 };
 
 export type Character = {
   slug: string;
   name: string;
-  title: string;
+  element: string;
   heroImage: string;
   heroImageAlt: string;
-  role: string;
-  element: string;
-  playstyle: string;
-  tips: string[];
-  lore: string;
-  mentality: string;
-  likes: string;
-  dislikes: string;
+  description: string;
   quote: string;
 };
 

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -203,11 +203,11 @@ export function createCharacterMetadata(
   const { locale: openGraphLocale, alternateLocales } = ogLocaleMap[locale] ?? ogLocaleMap[defaultLocale];
 
   return {
-    title: `${character.name} – ${character.title} | AIKA World`,
+    title: `${character.name} – ${character.element} | AIKA World`,
     description,
     alternates,
     openGraph: {
-      title: `${character.name} – ${character.title}`,
+      title: `${character.name} – ${character.element}`,
       description: ogDescription,
       url: canonical,
       siteName: 'AIKA World',
@@ -225,7 +225,7 @@ export function createCharacterMetadata(
     },
     twitter: {
       card: 'summary_large_image',
-      title: `${character.name} – ${character.title}`,
+      title: `${character.name} – ${character.element}`,
       description,
       images: [character.heroImage]
     }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
     content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
-    safelist: ['bg-accentA', 'bg-accentB', 'bg-accentC', 'bg-accentD', 'bg-accentE'],
+    safelist: ['bg-accentA', 'bg-accentB', 'bg-accentC', 'bg-accentD', 'bg-accentE', 'bg-accentF'],
     theme: {
         extend: {
             colors: {
@@ -11,7 +11,8 @@ module.exports = {
                 accentB: '#4DB3FF', // Komi (víz)
                 accentC: '#8FF7C8', // Yui (szél)
                 accentD: '#A78BFA', // Hina (penge)
-                accentE: '#FFD166'  // Miyu (heal)
+                accentE: '#FFD166', // Miyu (heal)
+                accentF: '#6C63FF'  // AIKA (void)
             }
         }
     },


### PR DESCRIPTION
## Summary
- Replace the character data with dark poetic summaries and quotes for Akari, Miyu, Komi, Hina, Yui, and AIKA.
- Simplify the character listing and profile pages to highlight each resonator’s element, short description, and signature quote.
- Refresh home page character cards, localization dictionaries, SEO text, and accent colors to match the new roster.

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e61d1678188325ab00c365077c7953