### PR TITLE
Add About the Game section to presskit

### DIFF
--- a/app/presskit/page.tsx
+++ b/app/presskit/page.tsx
@@ -36,6 +36,14 @@ export default async function PresskitPage() {
           <p className="mt-4 text-base md:text-lg opacity-90">{dictionary.presskit.description}</p>
         </section>
 
+        <section className="rounded-3xl border border-white/10 bg-white/5 p-6 md:p-8 space-y-4">
+          <h2 className="text-2xl font-semibold">{dictionary.presskit.about.title}</h2>
+          <p className="text-base md:text-lg opacity-90">{dictionary.presskit.about.intro}</p>
+          <p className="text-base md:text-lg opacity-80">{dictionary.presskit.about.keyMessage}</p>
+          <p className="text-sm md:text-base italic text-white/80">{dictionary.presskit.about.craft}</p>
+          <p className="text-base md:text-lg font-semibold text-accentB">{dictionary.presskit.about.tagline}</p>
+        </section>
+
         <section className="grid gap-6 md:grid-cols-2">
           <div className="rounded-2xl border border-white/10 bg-white/5 p-6 md:col-span-2">
             <h2 className="text-xl font-semibold">{dictionary.presskit.factSheetTitle}</h2>

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -640,6 +640,14 @@ export const enDictionary: Dictionary = {
   presskit: {
     heading: 'AIKA World Presskit',
     description: 'All press and creator assets in one place. Free to use under the conditions below.',
+    about: {
+      title: 'About the Game',
+      intro:
+        'AIKA World is a single-player, story-driven pilgrimage traced along the fault line between human memory and an engineered divinity.',
+      keyMessage: 'No multiplayer. No loot. No ranking—only story, sound, and light.',
+      craft: 'Built with Unreal Engine. Composed by the Resonance.',
+      tagline: 'You don’t play AIKA World. You remember it.'
+    },
     factSheetTitle: 'Fact sheet',
     downloadsTitle: 'Downloadable assets',
     usageTitle: 'Usage guidelines',

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -641,6 +641,14 @@ export const huDictionary: Dictionary = {
   presskit: {
     heading: 'AIKA World Presskit',
     description: 'Minden sajtó- és tartalomkészítői anyag egy helyen. Szabadon felhasználhatóak a lenti feltételek mellett.',
+    about: {
+      title: 'About the Game',
+      intro:
+        'AIKA World is a single-player, story-driven pilgrimage traced along the fault line between human memory and an engineered divinity.',
+      keyMessage: 'No multiplayer. No loot. No ranking—only story, sound, and light.',
+      craft: 'Built with Unreal Engine. Composed by the Resonance.',
+      tagline: 'You don’t play AIKA World. You remember it.'
+    },
     factSheetTitle: 'Fact sheet',
     downloadsTitle: 'Letölthető anyagok',
     usageTitle: 'Felhasználási feltételek',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -216,6 +216,13 @@ export type Character = {
 export type PresskitDictionary = {
   heading: string;
   description: string;
+  about: {
+    title: string;
+    intro: string;
+    keyMessage: string;
+    craft: string;
+    tagline: string;
+  };
   factSheetTitle: string;
   downloadsTitle: string;
   usageTitle: string;


### PR DESCRIPTION
## Summary
- add a dedicated About the Game section to the presskit page highlighting the single-player narrative focus
- extend the English and Hungarian dictionaries plus types to support the new copy block

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6212c02e88325b771d889acbaa6f0