### PR TITLE
Limit home game modes to story mode

### DIFF
--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -219,19 +219,26 @@ export default function HomePage({
           {dictionary.modes.cards.map(card => (
             <div key={card.title} className="rounded-xl border border-white/10 p-6 bg-white/5 flex flex-col">
               <h3 className="text-xl font-semibold">{card.title}</h3>
-              <p className="mt-2 opacity-90">{card.description}</p>
-              <ul className="mt-4 list-disc list-inside opacity-80 text-sm">
-                {card.points.map(point => (
-                  <li key={point}>{point}</li>
-                ))}
-              </ul>
-              <Link
-                href={card.href}
-                className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-accentB hover:opacity-80"
-              >
-                {card.linkLabel}
-                <span aria-hidden>→</span>
-              </Link>
+              {card.subtitle ? <p className="mt-1 text-sm uppercase tracking-wide opacity-70">{card.subtitle}</p> : null}
+              {card.body || card.description ? (
+                <p className="mt-2 opacity-90">{card.body ?? card.description}</p>
+              ) : null}
+              {card.points?.length ? (
+                <ul className="mt-4 list-disc list-inside opacity-80 text-sm">
+                  {card.points.map(point => (
+                    <li key={point}>{point}</li>
+                  ))}
+                </ul>
+              ) : null}
+              {card.linkLabel && card.href ? (
+                <Link
+                  href={card.href}
+                  className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-accentB hover:opacity-80"
+                >
+                  {card.linkLabel}
+                  <span aria-hidden>→</span>
+                </Link>
+              ) : null}
             </div>
           ))}
         </div>

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -125,40 +125,10 @@ export const enDictionary: Dictionary = {
     title: 'Game Modes',
     cards: [
       {
-        title: 'Raid Boss Arena',
-          description:
-            "Drop into a five-player co-op boss gauntlet where every arena reveals layered mechanics without spoiling the finale. Master tells, stagger windows, and arena hazards to carve openings for your Resonators. Coordinated cooldowns and revives decide whether the squad extracts rare materials or wipes.",
-          points: [
-            'Five-player co-op boss encounters',
-            'Layered mechanics without spoilers',
-            'Shared loot and mastery rewards'
-          ],
-          linkLabel: 'See details',
-          href: '#'
-        },
-        {
-          title: 'Infest Survival',
-          description:
-            'Hold choke points against endless waves that escalate with corrupt variants while keeping momentum spoiler-free. Every cleared milestone unlocks checkpoint rewards—temporary buffs, crafting drops, or extraction intel—before the swarm resets. Rotate roles, bank resources, and decide when to push deeper or secure the run.',
-          points: [
-            'Endless wave escalation',
-            'Checkpoint rewards to bank',
-            'Risk-versus-reward extractions'
-          ],
-          linkLabel: 'See details',
-          href: '#'
-        },
-        {
-          title: 'Open World Expedition',
-          description:
-            "Scout the overworld at your squad's pace, uncovering biomes, hubs, and lore breadcrumbs without revealing twists. Parkour routes, traversal gadgets, and dynamic weather alter every expedition. Track world events, unlock shortcuts, and gather intel that fuels raids and infest runs while staying spoiler-safe.",
-          points: [
-            'Exploration-first pacing',
-            'Traversal tools and weather shifts',
-            'Intel that feeds raids and infest'
-          ],
-          linkLabel: 'See details',
-          href: '#'
+        title: 'Story Mode',
+        subtitle: 'Descend alone',
+        body:
+          'A melancholic, dark sci-fi journey where you face AIKA and the echoes of a lost world. No co-op. No live service. Just the story.'
       }
     ]
   },

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -46,10 +46,12 @@ export type HomeDictionary = {
     title: string;
     cards: {
       title: string;
-      description: string;
-      points: string[];
-      linkLabel: string;
-      href: string;
+      subtitle?: string;
+      body?: string;
+      description?: string;
+      points?: string[];
+      linkLabel?: string;
+      href?: string;
     }[];
   };
   characters: {


### PR DESCRIPTION
## Summary
- remove the raid, infest, and expedition game mode cards from the English dictionary so only Story Mode remains with updated copy
- adjust the home dictionary types and home page component to support the new Story Mode fields while gracefully handling optional legacy data

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e628e92a108325af58d90edb153396