### PR TITLE
Refocus progression copy and roadmap milestones

### DIFF
--- a/app/(marketing)/progression/page.tsx
+++ b/app/(marketing)/progression/page.tsx
@@ -18,38 +18,15 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function ProgressionPage() {
   const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
-  const sections = dictionary.progression.sections;
+  const { title, body } = dictionary.progression;
 
   return (
     <SiteLayout locale={locale} dictionary={dictionary}>
-      <div className="mx-auto max-w-5xl px-4 py-16 space-y-16">
-        <header>
-          <h1 className="text-3xl md:text-4xl font-bold">{dictionary.progression.title}</h1>
-          <p className="mt-4 max-w-3xl text-base md:text-lg opacity-90">{dictionary.progression.intro}</p>
+      <div className="mx-auto max-w-4xl px-4 py-16 space-y-10">
+        <header className="space-y-4">
+          <h1 className="text-3xl md:text-4xl font-bold">{title}</h1>
+          <p className="text-base md:text-lg opacity-90">{body}</p>
         </header>
-
-        <div className="space-y-12">
-          {sections.map(section => (
-            <section key={section.id} id={section.id} aria-labelledby={`${section.id}-title`} className="scroll-mt-24">
-              <div className="rounded-3xl border border-white/10 bg-white/5 p-8 md:p-10 shadow-lg shadow-black/20">
-                <div className="md:max-w-xl">
-                  <h2 id={`${section.id}-title`} className="text-2xl md:text-3xl font-semibold">
-                    {section.title}
-                  </h2>
-                  <p className="mt-3 text-sm md:text-base opacity-80">{section.summary}</p>
-                </div>
-                <ul className="mt-6 space-y-3 text-sm md:text-base opacity-90">
-                  {section.bullets.map(point => (
-                    <li key={point} className="flex items-start gap-3">
-                      <span aria-hidden className="mt-1 inline-block h-2 w-2 rounded-full bg-accentB" />
-                      <span>{point}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </section>
-          ))}
-        </div>
       </div>
     </SiteLayout>
   );

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -298,16 +298,15 @@ export default function HomePage({
       <section id="roadmap" className="mx-auto max-w-6xl px-4 py-16">
         <h2 className="text-2xl md:text-3xl font-bold">{dictionary.roadmap.title}</h2>
         <ol className="mt-6 relative border-s border-white/10 ps-6">
-          {dictionary.roadmap.phases.map((phase, index) => (
-            <li key={phase.badge} className="mb-6 last:mb-0">
+          {[dictionary.roadmap.phase1, dictionary.roadmap.phase2, dictionary.roadmap.phase3].map((phase, index) => (
+            <li key={phase.title} className="mb-6 last:mb-0">
               <div
                 className={`absolute -start-[6px] mt-1.5 h-3 w-3 rounded-full ${
                   ['bg-accentA', 'bg-accentD', 'bg-accentB'][index % 3]
                 }`}
               />
-              <h3 className="font-semibold">{phase.badge}</h3>
-              <p className="opacity-80 text-sm">{phase.title}</p>
-              <p className="opacity-70 text-sm">{phase.description}</p>
+              <h3 className="font-semibold">{phase.title}</h3>
+              <p className="opacity-80 text-sm">{phase.body}</p>
             </li>
           ))}
         </ol>

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -156,23 +156,18 @@ export const enDictionary: Dictionary = {
     },
     roadmap: {
       title: 'Roadmap',
-      phases: [
-        {
-          badge: 'v1 – Raid + Infest',
-          title: 'Co-op PvE launch',
-          description: 'Team-based boss hunts with cosmetic progression.'
-        },
-        {
-          badge: 'v2 – Story Mode',
-          title: 'Narrative arc',
-          description: 'Slice-of-life tone, meaningful choices and branching scenes.'
-        },
-        {
-          badge: 'v3 – Toward MMO',
-          title: 'Shared-world upgrade',
-          description: 'Social hub, factions and persistent community systems.'
-        }
-      ]
+      phase1: {
+        title: 'Chapter I — Awakening',
+        body: 'Core single-player story, foundational systems, first descent.'
+      },
+      phase2: {
+        title: 'Chapter II — The Core Loop',
+        body: 'Expanded narrative arcs, new encounters, deeper echo mechanics.'
+      },
+      phase3: {
+        title: 'Future DLC — Separate Multiplayer',
+        body: 'If released, multiplayer will be a separate title or DLC. Not part of the core story game.'
+      }
     },
     community: {
       title: 'Community hub',
@@ -319,40 +314,9 @@ export const enDictionary: Dictionary = {
     ]
   },
   progression: {
-    title: 'Progression teaser',
-    intro: 'A spoiler-free glimpse at how squads grow in AIKA World before full reveals.',
-    sections: [
-      {
-        id: 'resonance-skill',
-        title: 'Resonance skill',
-        summary: 'Signature resonance bursts deepen with coordinated play without exposing the complete skill web.',
-        bullets: [
-          'Chain resonance windows to unlock optional augment slots that alter your ultimate flow.',
-          'Earn resonance sparks from flawless clears to reroute ability behaviours between missions.',
-          'Blend support catalysts to extend combo uptime and rewrite finisher effects for the squad.'
-        ]
-      },
-      {
-        id: 'gear-evolution',
-        title: 'Gear evolution',
-        summary: 'Weapons and suits adapt through modular crafting loops instead of tier spreadsheets.',
-        bullets: [
-          'Refine expedition drops into adaptive cores that shift perk loadouts per activity.',
-          'Slot evolution plates to morph silhouettes and add traversal bonuses without revealing stats.',
-          'Trade duplicate finds for forge favours that fast-track bespoke weapon paths.'
-        ]
-      },
-      {
-        id: 'hub-customization',
-        title: 'Hub customization',
-        summary: 'Your safe hub grows with mood pieces and utilities as bonds deepen—no plot spoilers.',
-        bullets: [
-          'Curate district wings with earned decor sets that boost resting bonuses.',
-          'Unlock rehearsal rooms that rotate social buffs and mini training encounters.',
-          'Commission ambient tracks and lighting presets to broadcast your squad identity.'
-        ]
-      }
-    ]
+    title: 'Progression',
+    body:
+      'Advance through memories and resonance echoes. Unlock fragments of AIKA’s past, new scenes, and altered perspectives.'
   },
   devlog: {
     heading: 'Devlog timeline',

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -186,23 +186,18 @@ export const huDictionary: Dictionary = {
     },
     roadmap: {
       title: 'Roadmap',
-      phases: [
-        {
-          badge: 'v1 – Raid + Infest',
-          title: 'Kooperatív PvE rajt',
-          description: 'Csapat alapú boss vadászat kozmetikai progresszióval.'
-        },
-        {
-          badge: 'v2 – Story Mode',
-          title: 'Narratív ív',
-          description: 'Slice-of-life hangulat, jelentős döntések és elágazó jelenetek.'
-        },
-        {
-          badge: 'v3 – MMO irány',
-          title: 'Megosztott világ fejlesztés',
-          description: 'Közösségi HUB, frakciók és perzisztens rendszer.'
-        }
-      ]
+      phase1: {
+        title: 'I. fejezet — Ébredés',
+        body: 'Az alap egyszemélyes történet, a fundamentális rendszerek és az első alászállás.'
+      },
+      phase2: {
+        title: 'II. fejezet — A magciklus',
+        body: 'Bővített narratív ívek, új találkozások, mélyebb visszhang mechanikák.'
+      },
+      phase3: {
+        title: 'Jövőbeli DLC — Különálló multiplayer',
+        body: 'Ha megjelenik, a multiplayer külön címként vagy DLC-ként érkezik. Nem része az alap sztori játéknak.'
+      }
     },
     community: {
       title: 'Közösségi központ',
@@ -349,41 +344,9 @@ export const huDictionary: Dictionary = {
     ]
   },
   progression: {
-    title: 'Fejlődés teaser',
-    intro: 'Spoilermentes ízelítő arról, hogyan fejlődik a csapat az AIKA Worldben.',
-    sections: [
-      {
-        id: 'resonance-skill',
-        title: 'Rezonancia-képesség',
-        summary: 'A szignatúra rezonancia végső koordinált játékkal mélyül, a teljes képességfa felfedése nélkül.',
-        bullets: [
-          'Fűzd össze a rezonancia ablakokat, hogy opcionális augment slotokat oldj fel és átformáld az ulti ritmusát.',
-          'Tökéletes teljesítésekből rezonancia-szikrákat gyűjtesz, amelyekkel küldetések között átírhatod a képességviselkedést.',
-          'Támogató katalizátorokkal kitolod a kombóidőt, és új befejező hatásokat hangolsz a csapatnak.'
-        ]
-      },
-      {
-        id: 'gear-evolution',
-        title: 'Felszerelés evolúció',
-        summary: 'A fegyverek és öltözékek moduláris kraftolással alkalmazkodnak, tier táblázatok nélkül.',
-        bullets: [
-          'Az expedíciós droppokból adaptív magokat finomítasz, amelyek aktivitásonként átrendezik a perk készletet.',
-          'Evolúciós lapkákat pattintasz a páncélra, hogy formát és mozgásbónuszokat válts statisztika-spoiler nélkül.',
-          'A duplikált leleteket kovácsműhely-szívességekre cseréled, így saját fegyverútvonalakat gyorsítasz.'
-        ]
-      },
-      {
-        id: 'hub-customization',
-        title: 'Hub testreszabás',
-        summary:
-          'A biztonságos hub hangulati elemekkel és hasznos funkciókkal bővül, ahogy mélyülnek a kötelékek – történetspoilerek nélkül.',
-        bullets: [
-          'Negyedszárnyakat rendezel be megszerzett dekor szettekkel, amelyek pihenési bónuszokat adnak.',
-          'Próbaszobákat nyitsz, ahol forgó közösségi buffok és mini edzések érhetők el.',
-          'Ambient zenéket és fény preseteket rendelsz meg, hogy sugározd a csapat identitását.'
-        ]
-      }
-    ]
+    title: 'Fejlődés',
+    body:
+      'Haladj emlékeken és rezonancia visszhangokon át. Tárd fel AIKA múltjának töredékeit, új jeleneteket és átírt perspektívákat.'
   },
   devlog: {
     heading: 'Devlog idővonal',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -74,11 +74,18 @@ export type HomeDictionary = {
   };
   roadmap: {
     title: string;
-    phases: {
-      badge: string;
+    phase1: {
       title: string;
-      description: string;
-    }[];
+      body: string;
+    };
+    phase2: {
+      title: string;
+      body: string;
+    };
+    phase3: {
+      title: string;
+      body: string;
+    };
   };
   community: {
     title: string;
@@ -180,17 +187,9 @@ export type ModesDictionary = {
   }[];
 };
 
-export type ProgressionSectionDictionary = {
-  id: string;
-  title: string;
-  summary: string;
-  bullets: string[];
-};
-
 export type ProgressionDictionary = {
   title: string;
-  intro: string;
-  sections: ProgressionSectionDictionary[];
+  body: string;
 };
 
 export type CharactersDictionary = {


### PR DESCRIPTION
## Summary
- replace the progression copy with a narrative, single-player focused description in the English and Hungarian dictionaries
- restructure the roadmap dictionary entries to highlight single-player chapters and position multiplayer as a future DLC, updating both locales
- adjust the homepage and progression page components, plus related types, to consume the new dictionary shapes

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e629d15b1483258b9c7a9538c7a8a3