### PR TITLE
Remove multiplayer mode links from navigation

### DIFF
--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -8,7 +8,7 @@ export const enDictionary: Dictionary = {
     navLabel: 'Primary navigation',
     nav: {
       world: { label: 'World', href: '/lore/elyndra' },
-      modes: { label: 'Modes', href: '/modes' },
+      modes: { label: 'Story', href: '/modes' },
       progression: { label: 'Progression', href: '/progression' },
       devlog: { label: 'Dev Journal', href: '/dev-journal' },
       faq: { label: 'FAQ', href: '/faq' }
@@ -27,7 +27,7 @@ export const enDictionary: Dictionary = {
       navigation: [
         { path: '/lore/elyndra', label: 'Lore: Elyndra' },
         { path: '/#world', label: 'World' },
-        { path: '/modes', label: 'Modes' },
+        { path: '/modes', label: 'Story Mode' },
         { path: '/progression', label: 'Progression' },
         { path: '/dev-journal', label: 'Dev Journal' },
         { path: '/faq', label: 'FAQ' }
@@ -238,78 +238,32 @@ export const enDictionary: Dictionary = {
   },
   modes: {
     navLabel: 'Section navigation',
-    heading: 'AIKA World game modes',
+    heading: 'AIKA World Story Mode',
     intro:
-      'Immerse yourself in co-op challenges forged across Pyro, Verdefa, Nerei, Aurelia and Nocturnis: the Raid Boss Arena rewards precision, Infest Survival celebrates adaptive endurance, and Story Mode deepens narrative bonds. Use these guides to prepare your squad for every mode.',
+      'AIKA World is a solitary, narrative-driven descent across Elyndra. This guide gathers the key beats, rewards and playstyle notes so you can prepare for the journey on your own terms.',
     backToHome: 'Back to homepage',
     sections: [
       {
-        id: 'raid',
-        title: 'Raid Boss Arena',
-        tagline: 'Gargantuan bosses, multi-phase showdowns and raid-tier coordination.',
-        mechanicsTitle: 'Core mechanics',
-        rewardsTitle: 'Rewards',
-        rolesTitle: 'Team roles',
-        mechanics: [
-          'Dynamic boss phases with timed wipe mechanics and unique debuffs.',
-          'Arena modulators that add rotating environmental hazards each week.',
-          'Party-size scaling for three to five players with bespoke health and damage curves.'
-        ],
-        rewards: [
-          'Legendary loot tokens that craft the seasonal weapon skin.',
-          'Rank XP for the Raid Ladder with weekly resets and cosmetic frames.',
-          'Exclusive emotes and banner effects for flawless clears.'
-        ],
-        roles: [
-          'Vanguard (Tank): swap shields and anchor the boss away from ranged conduits.',
-          'Resonator (DPS): exploit burst windows during Resonance Chains and focus on mechanics.',
-          'Harmonics (Support): time cleanses and maintain overheal shields for raid-wide damage.'
-        ]
-      },
-      {
-        id: 'infest',
-        title: 'Infest Survival',
-        tagline: 'Escalating horde mode with adaptive AI and checkpoint-driven progression.',
-        mechanicsTitle: 'Core mechanics',
-        rewardsTitle: 'Rewards',
-        rolesTitle: 'Team roles',
-        mechanics: [
-          'Procedurally generated wave patterns that react to your squad composition.',
-          'Infest Alert level that accelerates mutants and injects special affixes.',
-          'Cooperative resource management: ammo routing, drone calls and fortification builds.'
-        ],
-        rewards: [
-          'Biomass caches that upgrade the camp module and unlock perk slots.',
-          'Checkpoint credits that allow mid-run exits without losing rewards.',
-          'Season pass XP boosts and weekly challenges for bonus cosmetic tokens.'
-        ],
-        roles: [
-          'Crowd Control Specialist: thins the swarm with AoE resonance and slows sprinters.',
-          'Objective Runner: agile character who activates relay points and retrieves supply drops.',
-          'Field Medic: fast revives and stim injections that stack defensive damage reduction.'
-        ]
-      },
-      {
         id: 'story',
         title: 'Story Mode',
-        tagline: 'Narrative co-op with impactful choices, character growth and hub building.',
-        mechanicsTitle: 'Core mechanics',
-        rewardsTitle: 'Rewards',
-        rolesTitle: 'Team roles',
+        tagline: 'Solo narrative descent with resonant combat, meaningful choices and hub restoration.',
+        mechanicsTitle: 'Core beats',
+        rewardsTitle: 'Progression',
+        rolesTitle: 'Playstyle focus',
         mechanics: [
-          'Branching dialogue that shapes Resonator relationships and the state of your hub.',
-          'Cooperative decision voting during pivotal moral-choice set pieces.',
-          'Tactical social encounters that leverage both combat builds and narrative stats.'
+          'Story chapters that branch through dialogue, exploration choices and memory recoveries.',
+          'Resonance combat encounters tuned for a single protagonist with adaptive difficulty shifts.',
+          'Hub rebuilding activities that unlock workstations, allies and new side stories.'
         ],
         rewards: [
-          'Story Essence used to unlock personal skill extensions and cinematic scenes.',
-          'Hub upgrade modules: new crafting stations, relaxation zones and interactive minigames.',
-          'Exclusive cosmetics and emotes reflecting the narrative paths you chose.'
+          'Story Essence to expand skill constellations and unlock cinematic memories.',
+          'Restored hub facilities such as crafting alcoves, meditation rooms and lore archives.',
+          'Cosmetic artifacts earned at key narrative milestones and optional objectives.'
         ],
         roles: [
-          'Narrative Lead: high empathy stat to steer conversations and open bonus dialogue branches.',
-          'Intel Specialist: scouts environments, gathers lore intel and uncovers hidden rewards.',
-          'Anchor Player: coordinates group decisions, tracks quest objectives and timing windows.'
+          'Explorer: chart every route to uncover echoes, lore caches and hidden upgrades.',
+          'Strategist: balance resonance builds, resources and timing for each encounter.',
+          'Archivist: piece together intel to unlock optional conversations and alternate endings.'
         ]
       }
     ]

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -8,7 +8,7 @@ export const huDictionary: Dictionary = {
     navLabel: 'Fő navigáció',
     nav: {
       world: { label: 'Világ', href: '/lore/elyndra' },
-      modes: { label: 'Játékmódok', href: '/modes' },
+      modes: { label: 'Story mód', href: '/modes' },
       progression: { label: 'Fejlődés', href: '/progression' },
       devlog: { label: 'Fejlesztői napló', href: '/dev-journal' },
       faq: { label: 'GYIK', href: '/faq' }
@@ -27,7 +27,7 @@ export const huDictionary: Dictionary = {
       navigation: [
         { path: '/lore/elyndra', label: 'Mítosz: Elyndra' },
         { path: '/#world', label: 'Világ' },
-        { path: '/modes', label: 'Játékmódok' },
+        { path: '/modes', label: 'Story mód' },
         { path: '/progression', label: 'Fejlődés' },
         { path: '/dev-journal', label: 'Fejlesztői napló' },
         { path: '/faq', label: 'GYIK' }
@@ -238,78 +238,32 @@ export const huDictionary: Dictionary = {
   },
   modes: {
     navLabel: 'Szöveges horgonyok',
-    heading: 'AIKA World játékmódok',
+    heading: 'AIKA World Story mód',
     intro:
-      'Merülj el Pyro, Verdefa, Nerei, Aurelia és Nocturnis kooperatív kihívásaiban: a Raid Boss Arena a precíz végrehajtást, az Infest Survival az adaptív túlélést jutalmazza, a Story Mode pedig mélyíti a narratívát és a karakterkapcsolatokat. Az alábbi útmutatók segítenek felkészülni mindegyik módra.',
+      'Az AIKA World egy magányos, narratív utazás Elyndra romjai között. Ez az útmutató összegyűjti a fő ritmusokat, jutalmakat és játékstílus fókuszokat, hogy a saját tempódban készülhess fel az útra.',
     backToHome: 'Vissza a főoldalra',
     sections: [
       {
-        id: 'raid',
-        title: 'Raid Boss Arena',
-        tagline: 'Óriási bossok, többfázisú összecsapások és raid-szintű koordináció.',
-        mechanicsTitle: 'Kulcsmechanikák',
-        rewardsTitle: 'Jutalmak',
-        rolesTitle: 'Csapat szerepek',
-        mechanics: [
-          'Dinamikus boss fázisok időzített wipe-mekanikákkal és egyedi debuffokkal.',
-          'Aréna modulátorok, amelyek minden héten extra környezeti veszélyt adnak hozzá.',
-          'Party-size skálázás 3–5 játékos között, külön HP és sebzés görbével.'
-        ],
-        rewards: [
-          'Legendary-tier loot tokenek, amelyekből craftolható a szezonális fegyver skin.',
-          'Rank XP a Raid Ladderhez, heti resetekkel és kozmetikai rangkeretekkel.',
-          'Egyedi emote-ok és banner effektusok a flawless (wipe nélküli) clearért.'
-        ],
-        roles: [
-          'Vanguard (Tank): pajzscsere és boss pozicionálás a távolsági kondivókon kívül.',
-          'Resonator (DPS): burst ablakok kihasználása Resonance Chainnél, mechanika fókuszban.',
-          'Harmonics (Support): cleanse időzítése, overheal pajzs fenntartása a raid-wide sebzésre.'
-        ]
-      },
-      {
-        id: 'infest',
-        title: 'Infest Survival',
-        tagline: 'Fokozódó horda mód adaptív AI-val és checkpoint alapú fejlődéssel.',
-        mechanicsTitle: 'Kulcsmechanikák',
-        rewardsTitle: 'Jutalmak',
-        rolesTitle: 'Csapat szerepek',
-        mechanics: [
-          'Procedurálisan generált wave-minták, amelyek reagálnak a squad buildjére.',
-          'Infest Alert szint, amely növeli a mutánsok sebességét és speciális affixeket hoz be.',
-          'Kooperatív erőforrás-menedzsment: ammo kiosztás, drón hívások és erődítés építés.'
-        ],
-        rewards: [
-          'Biomass cache-ek, amelyekből fejleszthető a tábor modul és új perk slotok nyílnak.',
-          'Checkpoint kreditek, amelyek lehetővé teszik a köztes kilépést jutalomvesztés nélkül.',
-          'Season pass XP boost és heti kihívások extra kozmetikai tokenekért.'
-        ],
-        roles: [
-          'Crowd Control Specialist: AoE rezgésekkel ritkítja a swarmot és lassítja a sprintereket.',
-          'Objective Runner: mozgékony karakter, aki aktiválja a relay pontokat és hozza a supply dropokat.',
-          'Field Medic: gyors revive és stimul injekció, amely stackelő sebzéscsökkentést ad a csapatnak.'
-        ]
-      },
-      {
         id: 'story',
         title: 'Story Mode',
-        tagline: 'Narratív kooperáció döntésekkel, karakterfejlődéssel és hub-építéssel.',
-        mechanicsTitle: 'Kulcsmechanikák',
-        rewardsTitle: 'Jutalmak',
-        rolesTitle: 'Csapat szerepek',
+        tagline: 'Magányos narratív alászállás rezonáns harccal, jelentős döntésekkel és hub-helyreállítással.',
+        mechanicsTitle: 'Fő elemek',
+        rewardsTitle: 'Fejlődés',
+        rolesTitle: 'Játékstílus fókusz',
         mechanics: [
-          'Branching dialógusok, amelyek befolyásolják a Resonatorok közötti kapcsolatokat és a hub állapotát.',
-          'Kooperatív döntéshozatal: a squad szavaz a kritikus moral choice jelenetekben.',
-          'Taktikai social encounters, amelyek a combat buildedet és a narratív statjaidat is használják.'
+          'Történeti fejezetek, amelyek párbeszédek, felfedezési döntések és emlékek visszaszerzése révén ágaznak el.',
+          'Rezonancia összecsapások, amelyeket egyetlen főhősre hangoltunk adaptív nehézségi váltásokkal.',
+          'Hub-újjáépítés, amely munkaállomásokat, szövetségeseket és új melléktörténeteket nyit meg.'
         ],
         rewards: [
-          'Story Essence, amely feloldja a személyes skill kiterjesztéseket és karakter cinematicokat.',
-          'Hub fejlesztési modulok: új crafting állomások, pihenő zónák és interaktív minijátékok.',
-          'Exkluzív vizuális kozmetikák és emote-ok, amelyek a történeti döntéseidet tükrözik.'
+          'Story Essence a képesség konstellációk bővítéséhez és a filmszerű emlékek feloldásához.',
+          'Felújított hub létesítmények: crafting fülkék, meditációs terek és lore archívumok.',
+          'Narratív mérföldkövekhez és opcionális célokhoz kötött kozmetikai relikviák.'
         ],
         roles: [
-          'Narrative Lead: magas empathy stattal moderálja a beszélgetéseket és extra dialógus ágakat nyit.',
-          'Intel Specialist: felderíti a környezetet, lore információkat gyűjt és rejtett jutalmakat fedez fel.',
-          'Anchor Player: koordinálja a kooperatív döntéseket, követi a quest célokat és időkereteket.'
+          'Felfedező: minden ösvényt bejár, hogy visszhangokat, lore cache-eket és rejtett fejlesztéseket találjon.',
+          'Stratéga: egyensúlyban tartja a rezonancia buildeket, az erőforrásokat és az összecsapások időzítését.',
+          'Archivista: összerakja az intel töredékeit, hogy extra párbeszédeket és alternatív befejezéseket nyisson meg.'
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- retitle the header and footer navigation entries to point to Story Mode instead of multiplayer offerings
- rewrite the Story Mode dictionary section so the /modes page only exposes the solo narrative content
- confirmed the Dev Journal link remains in the primary navigation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e644e443d08325b6f01eb86645a402