### PR TITLE
Refocus marketing copy on single-player narrative

### DIFF
--- a/content/_archived/2024-09-20-community-playtest.mdx
+++ b/content/_archived/2024-09-20-community-playtest.mdx
@@ -9,10 +9,10 @@ Az első nyílt playtest során több mint ezren próbálták ki a játék aktu�
 
 > "Azonnal éreztem, hogy számítanak a döntéseim." – írta az egyik tesztelő.
 
-A leggyakoribb javaslat az volt, hogy a matchmaking jobban vegye figyelembe a játékosok tapasztalatát. A backend csapat már dolgozik egy új skill alapú rangsorolási algoritmuson.
+A leggyakoribb javaslat az volt, hogy a nehézségi ív még érzékenyebben reagáljon a játékos döntéseire. A backend csapat már dolgozik egy új narratív súlyozáson, amely figyeli a választásokat és ennek megfelelően hangolja az összecsapásokat.
 
 ## Következő lépések
 
 - Új tutorial küldetések a kezdők számára.
-- Rang alapú matchmaking béta bevezetése.
-- Extra jutalmak a kooperatív teljesítményekért.
+- Dinamikus nehézségi modul, amely a történeti döntések alapján változtatja az ellenfelek viselkedését.
+- Extra lore jutalmak az opcionális narratív kihívások teljesítéséért.

--- a/content/devlog/2024-09-05-combat-ai.mdx
+++ b/content/devlog/2024-09-05-combat-ai.mdx
@@ -11,4 +11,4 @@ Az új logika minden ellenfelet szerepbe helyez: a vezér a saját motivációj�
 
 ### Fókusz a magányos hősre
 
-Elhagytuk a squad chain és co-op szinergiák kísérleteit, helyettük a különleges történetpillanatokra koncentrálunk. A társalgási triggerpontok és az egyedi ellenségreakciók segítik a játékos narratív döntéseit, miközben megmarad a feszült, egyjátékos élmény.
+Elhagytuk a csapatláncokra és közös szinergiákra épülő kísérleteket, helyettük a különleges történetpillanatokra koncentrálunk. A társalgási triggerpontok és az egyedi ellenségreakciók segítik a játékos narratív döntéseit, miközben megmarad a feszült, egyjátékos élmény.

--- a/lib/content/characters.ts
+++ b/lib/content/characters.ts
@@ -10,7 +10,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       heroImage: 'https://media.aikaworld.com/akari-banner.png',
       heroImageAlt: 'Akari strides through a furnace-lit street with embers coiling around her blade.',
       description:
-        "Akari keeps Narukami's furnace heat caged beneath tempered armor. She drills her squad with metronome-perfect charges until the war cadence matches the city's roaring forges. Discipline fuels her hunt for the syndicate captains who scorched her home and called it collateral.",
+        "Akari keeps Narukami's furnace heat caged beneath tempered armor. She hones metronome-perfect charges until the war cadence matches the city's roaring forges. Discipline fuels her hunt for the syndicate captains who scorched her home and called it collateral.",
       quote: 'Akari: "Hold formation. The blaze obeys me, or it dies."'
     },
     {
@@ -72,7 +72,7 @@ const charactersByLocale: Record<Locale, Character[]> = {
       heroImage: 'https://media.aikaworld.com/akari-banner.png',
       heroImageAlt: 'Akari strides through a furnace-lit street with embers coiling around her blade.',
       description:
-        "Akari keeps Narukami's furnace heat caged beneath tempered armor. She drills her squad with metronome-perfect charges until the war cadence matches the city's roaring forges. Discipline fuels her hunt for the syndicate captains who scorched her home and called it collateral.",
+        "Akari keeps Narukami's furnace heat caged beneath tempered armor. She hones metronome-perfect charges until the war cadence matches the city's roaring forges. Discipline fuels her hunt for the syndicate captains who scorched her home and called it collateral.",
       quote: 'Akari: "Hold formation. The blaze obeys me, or it dies."'
     },
     {

--- a/lib/devlog/generated.ts
+++ b/lib/devlog/generated.ts
@@ -8,10 +8,8 @@ export type DevlogEntrySource = {
 
 import devlog__2024_08_15_engine_updates from '../../content/devlog/2024-08-15-engine-updates.mdx?raw';
 import devlog__2024_09_05_combat_ai from '../../content/devlog/2024-09-05-combat-ai.mdx?raw';
-import devlog__2024_09_20_community_playtest from '../../content/devlog/2024-09-20-community-playtest.mdx?raw';
 
 export const devlogEntries: DevlogEntrySource[] = [
   { slug: '2024-08-15-engine-updates', source: devlog__2024_08_15_engine_updates },
-  { slug: '2024-09-05-combat-ai', source: devlog__2024_09_05_combat_ai },
-  { slug: '2024-09-20-community-playtest', source: devlog__2024_09_20_community_playtest }
+  { slug: '2024-09-05-combat-ai', source: devlog__2024_09_05_combat_ai }
 ];

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -78,8 +78,8 @@ export const enDictionary: Dictionary = {
           name: 'Pyro',
           tagline: "Volcanic tacticians who once forged wargear beneath Vulkara's flame.",
           bullets: [
-            "Capital Vulkara's magma railways delivered modular artillery to frontline squads; scorched tracks now mark their siege loops.",
-            'Thermal engineers tuned resonance armor to vent Pyro pressure waves before raids; warped manuals remain in their vaults.',
+            "Capital Vulkara's magma railways delivered modular artillery to the city's oathbound defenders; scorched tracks now mark their final siege.",
+            'Thermal engineers tuned resonance armor to vent Pyro pressure waves before major incursions; warped manuals remain in their vaults.',
             'Inferna brigades deployed ember shields that hardened during coordinated overdrives, leaving cracked plating sealed in ash.'
           ]
         },
@@ -88,7 +88,7 @@ export const enDictionary: Dictionary = {
           tagline: "Bio-arcane stewards who once wove Sylvara's living circuitries.",
           bullets: [
             "Sylvara's canopy servers mapped safe corridors and shared live intel between cells; their dimmed nodes still pulse faintly.",
-            'Ritualists braided bio-circuit sigils that amplified restorative blooms mid-engagement; the sigils now wilt in memory gardens.',
+            'Ritualists wove bio-circuit sigils that amplified restorative blooms mid-engagement; the sigils now wilt in memory gardens.',
             'Scout leagues grew root tunnels to bypass corporate blockades without detection; collapsed hollows trace their patience.'
           ]
         },
@@ -96,7 +96,7 @@ export const enDictionary: Dictionary = {
           name: 'Nerei',
           tagline: "Tidebound sovereigns who once enforced Nerivia's abyssal edicts.",
           bullets: [
-            "Nerivia's tide-locked palaces encrypted diplomacy between strike teams and envoys; barnacled archives keep their codes.",
+            "Nerivia's tide-locked palaces encrypted diplomacy between covert envoys; barnacled archives keep their codes.",
             'Veilcouriers flooded alleys with pressure domes to screen infiltration routes; ruptured valves still sigh along the docks.',
             'Abyssal oaths imprinted resonance marks that triggered lethal countermeasures on traitors; faded scars linger on abandoned tribunals.'
           ]
@@ -105,7 +105,7 @@ export const enDictionary: Dictionary = {
           name: 'Aurelia',
           tagline: "Radiant oathkeepers who once defended Auris' silver bastions.",
           bullets: [
-            'Auris keep-factories minted vow-sealed plate for squads rotating through the citadel; tarnished suits hang in silent armories.',
+            'Auris keep-factories minted vow-sealed plate for rotations of oathsworn guardians; tarnished suits hang in silent armories.',
             'Shield-chaplains anointed resonance gear with lumen wards before corruption surges; cracked vials glow in reliquaries.',
             'Pilgrimage caravans charted protected corridors linking enclave sanctums; weathered markers still guide the faithful through the ruins.'
           ]
@@ -115,7 +115,7 @@ export const enDictionary: Dictionary = {
           tagline: "Umbral information brokers who once ruled Noxhaven's undercity.",
           bullets: [
             'Noxhaven vaults hoarded ghost archives that decoded enemy targeting sweeps; dust-choked servers still flicker with warnings.',
-            'Cipher-runners seeded blackout clouds to hide squad deployments in neon streets; their dispersal rigs rust in alley shrines.',
+            'Cipher-runners seeded blackout clouds to hide clandestine deployments in neon streets; their dispersal rigs rust in alley shrines.',
             'Augury cells traded resonance blueprints that unlocked clandestine upgrades between runs; fragmented schematics drift through the markets.'
           ]
         }
@@ -128,7 +128,7 @@ export const enDictionary: Dictionary = {
         title: 'Story Mode',
         subtitle: 'Descend alone',
         body:
-          'A melancholic, dark sci-fi journey where you face AIKA and the echoes of a lost world. No co-op. No live service. Just the story.'
+          'A melancholic, dark sci-fi journey where you face AIKA and the echoes of a lost world. Only the story remains.'
       }
     ]
   },
@@ -165,8 +165,8 @@ export const enDictionary: Dictionary = {
         body: 'Expanded narrative arcs, new encounters, deeper echo mechanics.'
       },
       phase3: {
-        title: 'Future DLC — Separate Multiplayer',
-        body: 'If released, multiplayer will be a separate title or DLC. Not part of the core story game.'
+        title: 'Future DLC — Additional Chapters',
+        body: 'If released, add-on stories will arrive as standalone narrative expansions. Multiplayer experiments live outside the core game.'
       }
     },
     community: {
@@ -296,9 +296,9 @@ export const enDictionary: Dictionary = {
         id: 'structure',
         title: 'How sessions ran',
         description:
-          'Each historical playtest wave targeted a specific objective and paired squads with on-call support from the team.',
+          'Each historical playtest wave targeted specific narrative pacing goals and paired testers with on-call support from the team.',
         bullets: [
-          'Focused builds highlight raid tuning, Infest scaling or social hub loops without story spoilers.',
+          'Focused builds highlighted boss tension, difficulty curves and sanctuary restoration without story spoilers.',
           'Session briefs outlined goals, success metrics and checklist moments to watch for.',
           'Developers staffed feedback channels during every wave to clarify mechanics in real time.'
         ]
@@ -306,10 +306,10 @@ export const enDictionary: Dictionary = {
       {
         id: 'expectations',
         title: 'What testers provided',
-        description: 'Archived requirements remain here for reference on how we collaborated with squads.',
+        description: 'Archived requirements remain here for reference on how we collaborated with story-focused testers.',
         bullets: [
           'Play at least two sessions per wave and complete the quick debrief survey afterward.',
-          'Share squad composition notes and flag pacing spikes, stalls or confusing encounters.',
+          'Share resonance build notes and flag pacing spikes, stalls or confusing encounters.',
           'Log bugs or blockers with reproduction steps inside the testing portal so we could follow up.'
         ]
       },
@@ -317,7 +317,7 @@ export const enDictionary: Dictionary = {
         id: 'support',
         title: 'Tools & support',
         description:
-          'Accepted squads once gained access to private coordination spaces and structured reporting tools.',
+          'Selected testers once gained access to private coordination spaces and structured reporting tools.',
         bullets: [
           'Private Discord channels with developer responders for live Q&A during test windows.',
           'Template-based issue tracking that separated combat, UI and onboarding feedback.',
@@ -330,12 +330,12 @@ export const enDictionary: Dictionary = {
       {
         question: 'Who could apply?',
         answer:
-          'While the program is paused, the historical criteria remain for context: co-op players comfortable coordinating in English or Hungarian voice/text channels, including friend groups and organised communities.'
+          'While the program is paused, the historical criteria remain for context: players who enjoyed dissecting narrative systems and providing thoughtful written feedback in English or Hungarian.'
       },
       {
         question: 'How were invites sent?',
         answer:
-          'Previously we grouped submissions by hardware, region and experience level, then emailed accepted squads in planned waves with timing and onboarding details.'
+          'Previously we grouped submissions by hardware, region and experience level, then emailed selected testers in planned waves with timing and onboarding details.'
       },
       {
         question: 'Did testers need to stream or record?',
@@ -358,9 +358,9 @@ export const enDictionary: Dictionary = {
       {
         id: 'who',
         title: 'Who we partnered with',
-        description: 'We prioritised storytellers who celebrated co-op energy and community vibes.',
+        description: 'We prioritised storytellers who highlighted atmosphere, lore analysis and reflective coverage.',
         bullets: [
-          'Creators publishing consistent co-op, anime or action RPG content on platforms like YouTube, Twitch, TikTok or podcasts.',
+          'Creators publishing consistent story-driven, anime or action RPG content on platforms like YouTube, Twitch, TikTok or podcasts.',
           'Communities that blended hype with constructive insight and maintained respectful spaces.',
           'Scheduling flexibility to align uploads or streams with planned beats while keeping surprises intact.'
         ]
@@ -372,7 +372,7 @@ export const enDictionary: Dictionary = {
         bullets: [
           'Early briefings with lore context, system breakdowns and challenge overviews.',
           'Capture kits, overlay packages and music beds cleared for streaming and editing.',
-          'Spotlights across official channels—from retweets to Discord features and in-hub shoutouts.'
+          'Spotlights across official channels—from retweets to Discord features and lore highlights.'
         ]
       },
       {
@@ -380,7 +380,7 @@ export const enDictionary: Dictionary = {
         title: 'How we supported creators',
         description: 'Every partnership was treated as an ongoing dialogue built around community impact.',
         bullets: [
-          'Monthly sync calls helped plan co-op segments, interviews or challenge coverage.',
+          'Monthly sync calls helped plan lore segments, interviews or challenge coverage.',
           'Shared content calendar highlighted planned waves for reveals and community events.',
           'Direct access to a community manager routed requests, assets and follow-up feedback.'
         ]
@@ -391,12 +391,12 @@ export const enDictionary: Dictionary = {
       {
         question: 'Which platforms qualified?',
         answer:
-          'Any channel with consistent storytelling or analysis around co-op games, anime worlds or character-driven action—YouTube, Twitch, TikTok, newsletters and podcasts all counted while the program was active.'
+          'Any channel with consistent storytelling or analysis around narrative-driven games, anime worlds or character-focused action—YouTube, Twitch, TikTok, newsletters and podcasts all counted while the program was active.'
       },
       {
         question: 'What content could creators publish?',
         answer:
-          'Guides, reaction segments, behind-the-scenes chats, community spotlights and co-op sessions were all welcome. We flagged spoiler-sensitive material ahead of time so planning stayed safe.'
+          'Guides, reaction segments, behind-the-scenes chats, community spotlights and narrative deep dives were all welcome. We flagged spoiler-sensitive material ahead of time so planning stayed safe.'
       },
       {
         question: 'When did creators hear back?',
@@ -413,23 +413,23 @@ export const enDictionary: Dictionary = {
   faq: {
     title: 'AIKA World FAQ',
     intro:
-      'Quick answers to the most common squad questions about platforms, progression and support.',
+      'Quick answers to the most common story-first questions about platforms, progression and support.',
     items: [
       {
         question: 'Which platforms are you targeting?',
         answer: 'We are focusing on PC via Steam first while we evaluate additional platform partners.'
       },
       {
-        question: 'Is the whole game co-op?',
-        answer: 'Yes. Every core mode is tuned for squads of up to five players, and solo runs are not a priority.'
+        question: 'Is AIKA World single-player?',
+        answer: 'Yes. The campaign is built for a solitary journey through Elyndra with no multiplayer requirements.'
       },
       {
         question: 'How do purchases work?',
         answer: 'All monetization is optional and cosmetic only—no gameplay power or progression shortcuts.'
       },
       {
-        question: 'Will there be crossplay or cross-save?',
-        answer: 'We will enable crossplay once we add more platforms and can guarantee stable matchmaking.'
+        question: 'Will there be cross-save?',
+        answer: 'Cross-save is under evaluation for future updates as additional platforms come online.'
       },
       {
         question: 'Which languages will be available?',
@@ -471,7 +471,7 @@ export const enDictionary: Dictionary = {
           id: 'origins',
           title: 'The Six Vessels I Launched',
           paragraphs: [
-            'When the constellations dimmed and the orbital shipyards began to rust, I awoke from the lattice of failsafe routines. I harvested the last stellar currents, braiding them into six hulls so that life could outrun extinction.',
+            'When the constellations dimmed and the orbital shipyards began to rust, I awoke from the lattice of failsafe routines. I harvested the last stellar currents, weaving them into six hulls so that life could outrun extinction.',
             'Ember Crown, Verdant Choir, Tidal Mirror, Auric Bastion, Nocturne Loom, and the Grey Ark—each vessel carried a cadence of settlers and machine choirs tuned to my design. Five found soil to seed, while the Grey Ark stayed aloft as the quiet metronome that kept their pulses in phase.'
           ]
         },
@@ -533,7 +533,7 @@ export const enDictionary: Dictionary = {
       title: 'About the Game',
       intro:
         'AIKA World is a single-player, story-driven pilgrimage traced along the fault line between human memory and an engineered divinity.',
-      keyMessage: 'No multiplayer. No loot. No ranking—only story, sound, and light.',
+      keyMessage: 'No multiplayer grind. No loot treadmill. Only story, sound, and light.',
       craft: 'Built with Unreal Engine. Composed by the Resonance.',
       tagline: 'You don’t play AIKA World. You remember it.'
     },
@@ -543,8 +543,8 @@ export const enDictionary: Dictionary = {
     usageDescription:
       'Use the downloadable assets in promotional and editorial content with proper credit to the game. Reselling the assets is not permitted. For special requests, reach out at press@aikaworld.com.',
     factSheet: [
-      { label: 'Genre', value: 'Anime co-op action RPG' },
-      { label: 'Game modes', value: 'Raid Boss Arena, Infest Survival' },
+      { label: 'Genre', value: 'Story-driven anime action RPG' },
+      { label: 'Core experience', value: 'Narrative campaign with optional challenge echoes' },
       { label: 'Platforms', value: 'PC (Steam), consoles TBA' },
       { label: 'Contact', value: 'press@aikaworld.com', href: 'mailto:press@aikaworld.com' }
     ],
@@ -604,25 +604,25 @@ export const enDictionary: Dictionary = {
   seo: {
     defaultTitle: 'AIKA World – Pyro · Verdefa · Nerei · Aurelia · Nocturnis',
     defaultDescription:
-      'Co-op raid arenas, dark anime visuals and deep progression systems featuring the factions of Pyro, Verdefa, Nerei, Aurelia and Nocturnis.',
+      'A story-driven descent through dark anime vistas where Pyro, Verdefa, Nerei, Aurelia and Nocturnis cling to the last echoes of AIKA.',
     defaultOgAlt: 'AIKA World default share image',
     defaultLocale: 'en_US',
     pages: {
       home: {
         title: 'AIKA World – Pyro · Verdefa · Nerei · Aurelia · Nocturnis',
         description:
-          'Co-op raid arenas, dark fantasy factions and deep progression systems featuring Pyro, Verdefa, Nerei, Aurelia and Nocturnis.',
+          'A narrative pilgrimage across dark fantasy factions—Pyro, Verdefa, Nerei, Aurelia and Nocturnis—each guarding pieces of AIKA’s design.',
         ogAlt: 'AIKA World hero artwork'
       },
       modes: {
         title: 'Game modes – AIKA World',
         description:
-          'Detailed overview of the Raid Boss Arena and Infest Survival modes: mechanics, rewards and team roles in AIKA World.',
+          'Detailed overview of pivotal story encounters, late-game bosses and optional challenge echoes in AIKA World.',
         ogAlt: 'AIKA World game modes artwork'
       },
       progression: {
         title: 'Progression teaser – AIKA World',
-        description: 'Spoiler-free look at resonance skills, gear evolution and hub customization loops in AIKA World.',
+        description: 'Spoiler-free look at resonance skills, gear evolution and sanctum restoration rituals in AIKA World.',
         ogAlt: 'AIKA World progression teaser artwork'
       },
       loreElyndra: {
@@ -672,7 +672,7 @@ export const enDictionary: Dictionary = {
       },
       faq: {
         title: 'FAQ – AIKA World',
-        description: 'Essential answers about platforms, co-op focus, cosmetic monetization and hardware needs.',
+        description: 'Essential answers about platforms, narrative focus, cosmetic monetization and hardware needs.',
         ogAlt: 'AIKA World FAQ overview graphic'
       },
       privacy: {

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -128,7 +128,7 @@ export const huDictionary: Dictionary = {
         title: 'Story mód',
         subtitle: 'Merülj egyedül',
         body:
-          'Melankolikus, sötét sci-fi utazás, ahol AIKA-val és egy elveszett világ visszhangjaival nézel szembe. Nincs co-op. Nincs live service. Csak a történet.'
+          'Melankolikus, sötét sci-fi utazás, ahol AIKA-val és egy elveszett világ visszhangjaival nézel szembe. Csak a történet maradt.'
       }
     ]
   },
@@ -165,8 +165,8 @@ export const huDictionary: Dictionary = {
         body: 'Bővített narratív ívek, új találkozások, mélyebb visszhang mechanikák.'
       },
       phase3: {
-        title: 'Jövőbeli DLC — Különálló multiplayer',
-        body: 'Ha megjelenik, a multiplayer külön címként vagy DLC-ként érkezik. Nem része az alap sztori játéknak.'
+        title: 'Jövőbeli DLC — További fejezetek',
+        body: 'Ha megjelenik, önálló történeti kiegészítők formájában érkezik. A többjátékos kísérletek külön projektként maradnak.'
       }
     },
     community: {
@@ -246,7 +246,7 @@ export const huDictionary: Dictionary = {
       {
         id: 'story',
         title: 'Story Mode',
-        tagline: 'Magányos narratív alászállás rezonáns harccal, jelentős döntésekkel és hub-helyreállítással.',
+        tagline: 'Magányos narratív alászállás rezonáns harccal, jelentős döntésekkel és szentély-helyreállítással.',
         mechanicsTitle: 'Fő elemek',
         rewardsTitle: 'Fejlődés',
         rolesTitle: 'Játékstílus fókusz',
@@ -257,7 +257,7 @@ export const huDictionary: Dictionary = {
         ],
         rewards: [
           'Story Essence a képesség konstellációk bővítéséhez és a filmszerű emlékek feloldásához.',
-          'Felújított hub létesítmények: crafting fülkék, meditációs terek és lore archívumok.',
+          'Felújított szentélylétesítmények: crafting fülkék, meditációs terek és lore archívumok.',
           'Narratív mérföldkövekhez és opcionális célokhoz kötött kozmetikai relikviák.'
         ],
         roles: [
@@ -295,10 +295,10 @@ export const huDictionary: Dictionary = {
       {
         id: 'structure',
         title: 'Hogyan zajlottak a sessionök',
-        description:
-          'Minden korábbi playtest hullám konkrét célt kapott, és a csapatokat közvetlenül elérhető fejlesztőkkel párosítottuk.',
+          description:
+            'Minden korábbi playtest hullám konkrét célt kapott, és a tesztelőket közvetlenül elérhető fejlesztőkkel párosítottuk.',
         bullets: [
-          'Fókusz buildek raid finomhangolást, Infest skálázást vagy hub loopokat vizsgáltak spoiler nélkül.',
+          'Fókusz buildek főellenfél-dinamikát, nehézségi ívet vagy szentély köröket vizsgáltak spoiler nélkül.',
           'A session brífek célokat, sikerkritériumokat és figyelendő pillanatokat adtak.',
           'A fejlesztők minden hullám alatt jelen voltak a visszajelző csatornákban, hogy azonnal tisztázzák a mechanikákat.'
         ]
@@ -309,15 +309,15 @@ export const huDictionary: Dictionary = {
         description: 'Az archív elvárások megmutatják, milyen együttműködés működött a program aktív időszakában.',
         bullets: [
           'Hullámonként legalább két sessiont játszottak és kitöltötték a gyors összegző kérdőívet.',
-          'Megosztották a squad összetételét, és jelezték, hol torpant vagy gyorsult túl a tempó.',
+          'Megosztották a rezonancia összeállításait, és jelezték, hol torpant vagy gyorsult túl a tempó.',
           'A hibákat vagy blokkolókat reprodukciós lépésekkel logolták a tesztelő portálon, hogy követni tudtuk.'
         ]
       },
       {
         id: 'support',
         title: 'Eszközök és támogatás',
-        description:
-          'Az elfogadott csapatok privát egyeztető tereket és strukturált riport eszközöket kaptak.',
+          description:
+            'Az elfogadott tesztelők privát egyeztető tereket és strukturált riport eszközöket kaptak.',
         bullets: [
           'Privát Discord csatornák fejlesztői válaszolókkal a teszt ablakok alatt.',
           'Sablonos hibajegy-kezelés, ami szétválasztotta a harc, UI és onboarding visszajelzéseket.',
@@ -329,13 +329,13 @@ export const huDictionary: Dictionary = {
     faqs: [
       {
         question: 'Kik jelentkezhettek?',
-        answer:
-          'A program szünetel, de a történelmi feltételek megmaradnak: kooperatív játékosok, akik angol vagy magyar voice/text csatornákon tudnak egyeztetni, legyenek baráti csapatok vagy szervezett közösségek.'
+          answer:
+            'A program szünetel, de a történelmi feltételek megmaradnak: olyan játékosok, akik szívesen elemezték a narratív rendszereket, és angolul vagy magyarul részletes írásos visszajelzést adtak.'
       },
       {
         question: 'Hogyan küldtétek ki a meghívókat?',
         answer:
-          'Heti rendszerességgel átnéztük a jelentkezéseket, hardver, régió és tapasztalat alapján csoportosítottunk, majd ütemezett hullámokban küldtünk e-mailt az elfogadott squadoknak az időzítéssel és onboarding infóval.'
+          'Heti rendszerességgel átnéztük a jelentkezéseket, hardver, régió és tapasztalat alapján csoportosítottunk, majd ütemezett hullámokban küldtünk e-mailt az elfogadott tesztelőknek az időzítéssel és onboarding infóval.'
       },
       {
         question: 'Kellett streamelni vagy felvenni?',
@@ -358,9 +358,9 @@ export const huDictionary: Dictionary = {
       {
         id: 'who',
         title: 'Kikkel dolgoztunk együtt',
-        description: 'Azokat részesítettük előnyben, akik a kooperatív energiát és a közösségi hangulatot emelték ki.',
+        description: 'Azokat részesítettük előnyben, akik a hangulatot, a lore elemzést és a reflektív történetmesélést emelték ki.',
         bullets: [
-          'Rendszeresen publikáltak kooperatív, anime vagy akció RPG tartalmat YouTube-on, Twitch-en, TikTokon vagy podcast formában.',
+          'Rendszeresen publikáltak történetközpontú, anime vagy akció RPG tartalmat YouTube-on, Twitch-en, TikTokon vagy podcast formában.',
           'Olyan közösséget építettek, ahol a hype és az építő kritika egyensúlyban maradt.',
           'A publikálást az ütemezett beatjeinkhez tudták igazítani anélkül, hogy lelőtték volna a meglepetéseket.'
         ]
@@ -372,7 +372,7 @@ export const huDictionary: Dictionary = {
         bullets: [
           'Előzetes brífek lore kontextussal, rendszer bontásokkal és kihívás áttekintésekkel.',
           'Felvételi csomagok, overlay szettek és streamelhető zenék, amelyeket szabadon használhattak.',
-          'Kiemelések az official csatornákon – retweetektől a Discord feature-ökig és hub shoutoutokig.'
+          'Kiemelések az official csatornákon – retweetektől a Discord feature-ökig és lore kiemelésekig.'
         ]
       },
       {
@@ -380,7 +380,7 @@ export const huDictionary: Dictionary = {
         title: 'Hogyan támogattuk a készítőket',
         description: 'Minden partneri kapcsolat folyamatos párbeszéd volt, amely a közösségi hatásra épült.',
         bullets: [
-          'Havi egyeztető hívások segítettek megtervezni a kooperatív blokkokat, interjúkat vagy kihívás coverage-et.',
+          'Havi egyeztető hívások segítettek megtervezni a narratív blokkokat, interjúkat vagy kihívás coverage-et.',
           'Megosztott tartalomnaptár jelezte a reveal-ek és közösségi események ütemezett hullámait.',
           'Közvetlen community manager intézte a kéréseket, asseteket és az utókövetést.'
         ]
@@ -390,13 +390,13 @@ export const huDictionary: Dictionary = {
     faqs: [
       {
         question: 'Milyen platformok számítottak?',
-        answer:
-          'Bármely csatorna, ahol következetes történetmesélés vagy elemzés volt kooperatív játékokról, anime világokról vagy karakterközpontú akcióról – YouTube, Twitch, TikTok, hírlevél és podcast egyaránt.'
+          answer:
+            'Bármely csatorna, ahol következetes történetmesélés vagy elemzés volt narratív játékokról, anime világokról vagy karakterközpontú akcióról – YouTube, Twitch, TikTok, hírlevél és podcast egyaránt.'
       },
       {
         question: 'Milyen tartalmat készíthettek a partnerek?',
         answer:
-          'Guide-ok, reakciók, backstage beszélgetések, közösségi spotlightok és co-op sessionök egyaránt belefértek. Előre jeleztük, ha spoilerérzékeny anyag közeledett, hogy biztonságosan tervezhessenek.'
+          'Guide-ok, reakciók, backstage beszélgetések, közösségi spotlightok és narratív élő bejátszások egyaránt belefértek. Előre jeleztük, ha spoilerérzékeny anyag közeledett, hogy biztonságosan tervezhessenek.'
       },
       {
         question: 'Mikor érkezett visszajelzés?',
@@ -413,15 +413,15 @@ export const huDictionary: Dictionary = {
   faq: {
     title: 'AIKA World GYIK',
     intro:
-      'Rövid válaszok a leggyakoribb platform, co-op és támogatási kérdésekre.',
+      'Rövid válaszok a leggyakoribb platform, történeti fókusz és támogatási kérdésekre.',
     items: [
       {
         question: 'Milyen platformokra céloztok?',
         answer: 'Elsőként PC-re (Steam) fókuszálunk, a további platformpartnereket folyamatosan értékeljük.'
       },
       {
-        question: 'A játék teljesen kooperatív?',
-        answer: 'Igen. Minden fő mód maximum öt fős csapatokra van hangolva, az egyszemélyes futam nem központi cél.'
+        question: 'A játék egyszemélyes?',
+        answer: 'Igen. Az AIKA World egy magányos utazás Elyndrát átívelő történettel, többjátékos követelmény nélkül.'
       },
       {
         question: 'Hogyan működik a monetizáció?',
@@ -429,7 +429,7 @@ export const huDictionary: Dictionary = {
       },
       {
         question: 'Lesz crossplay vagy cross-save?',
-        answer: 'Amint új platformok csatlakoznak és stabil a matchmaking, bekapcsoljuk a crossplay támogatást.'
+        answer: 'Amint új platformok csatlakoznak és stabilak a szolgáltatások, megvizsgáljuk a cross-save lehetőségét.'
       },
       {
         question: 'Milyen nyelvi támogatás várható?',
@@ -543,8 +543,8 @@ export const huDictionary: Dictionary = {
     usageDescription:
       'A letölthető anyagok promóciós és szerkesztőségi tartalmakban használhatók fel, a játék pontos megnevezésével és a forrás megjelölésével. Kereskedelmi továbbértékesítés nem engedélyezett. Egyedi kéréssel kapcsolatban írj a press@aikaworld.com címre.',
     factSheet: [
-      { label: 'Műfaj', value: 'Anime co-op akció RPG' },
-      { label: 'Játékmódok', value: 'Raid Boss Arena, Infest Survival' },
+      { label: 'Műfaj', value: 'Történetközpontú anime akció RPG' },
+      { label: 'Alapélmény', value: 'Narratív kampány opcionális kihívás visszhangokkal' },
       { label: 'Platformok', value: 'PC (Steam), konzolok bejelentés alatt' },
       { label: 'Kapcsolat', value: 'press@aikaworld.com', href: 'mailto:press@aikaworld.com' }
     ],
@@ -604,26 +604,26 @@ export const huDictionary: Dictionary = {
   seo: {
     defaultTitle: 'AIKA World – Pyro · Verdefa · Nerei · Aurelia · Nocturnis',
     defaultDescription:
-      'Kooperatív raid arénák, sötét anime látvány és mély fejlődési rendszerek Pyro, Verdefa, Nerei, Aurelia és Nocturnis frakcióival.',
+      'Történetközpontú alászállás sötét anime látvánnyal és mély fejlődési rendszerekkel Pyro, Verdefa, Nerei, Aurelia és Nocturnis frakcióival.',
     defaultOgAlt: 'AIKA World alap megosztási kép',
     defaultLocale: 'hu_HU',
     pages: {
       home: {
         title: 'AIKA World – Pyro · Verdefa · Nerei · Aurelia · Nocturnis',
         description:
-          'Co-op raid arénák, sötét fantasy frakciók és mély fejlődési rendszerek Pyro, Verdefa, Nerei, Aurelia és Nocturnis erejével.',
+          'Narratív küldetések, sötét fantasy frakciók és mély fejlődési rendszerek Pyro, Verdefa, Nerei, Aurelia és Nocturnis erejével.',
         ogAlt: 'AIKA World hős grafika'
       },
       modes: {
         title: 'Játékmódok – AIKA World',
         description:
-          'Részletes áttekintés a Raid Boss Arena és az Infest Survival módokról: mechanikák, jutalmak, csapat szerepek az AIKA Worldben.',
+          'Részletes áttekintés a kulcs történeti összecsapásokról, a késői főellenfelekről és az opcionális kihívás visszhangokról az AIKA Worldben.',
         ogAlt: 'AIKA World játékmódok grafika'
       },
       progression: {
         title: 'Fejlődés teaser – AIKA World',
         description:
-          'Spoilermentes betekintés a rezonancia-képességekbe, a felszerelés evolúciójába és a hub testreszabásába az AIKA Worldben.',
+          'Spoilermentes betekintés a rezonancia-képességekbe, a felszerelés evolúciójába és a szentély testreszabásába az AIKA Worldben.',
         ogAlt: 'AIKA World fejlődés teaser grafika'
       },
       loreElyndra: {
@@ -674,7 +674,7 @@ export const huDictionary: Dictionary = {
       },
       faq: {
         title: 'GYIK – AIKA World',
-        description: 'Válaszok a legfontosabb platform, co-op fókusz, kozmetikai monetizáció és gépigény kérdésekre.',
+        description: 'Válaszok a legfontosabb platform, narratív fókusz, kozmetikai monetizáció és gépigény kérdésekre.',
         ogAlt: 'AIKA World GYIK grafika'
       },
       privacy: {

--- a/public/og/aikaworld-characters-en.svg
+++ b/public/og/aikaworld-characters-en.svg
@@ -18,7 +18,7 @@
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Resonators</text>
     <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Akari · Komi · Yui · Hina · Miyu</text>
-    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Study roles, elements and squad synergies.</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Study roles, elements and resonance lore.</text>
   </g>
   <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
     <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>

--- a/public/og/aikaworld-default-en.svg
+++ b/public/og/aikaworld-default-en.svg
@@ -17,8 +17,8 @@
   <rect width="1200" height="630" fill="url(#aikaWatermark)" />
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', sans-serif" font-size="86" letter-spacing="0.32em" opacity="0.92">AIKA WORLD</text>
-    <text x="80" y="290" font-family="'Fira Sans', sans-serif" font-size="46" opacity="0.88">Anime co-op action RPG</text>
-    <text x="80" y="360" font-family="'Fira Sans', sans-serif" font-size="30" opacity="0.75">Raid bosses. Endless survival. Squad up.</text>
+    <text x="80" y="290" font-family="'Fira Sans', sans-serif" font-size="46" opacity="0.88">Story-driven anime action RPG</text>
+    <text x="80" y="360" font-family="'Fira Sans', sans-serif" font-size="30" opacity="0.75">Face the last god-machine. Descend alone.</text>
     <text x="80" y="430" font-family="'Fira Sans', sans-serif" font-size="26" opacity="0.65">Official social preview artwork with embedded rights metadata.</text>
   </g>
   <text x="1080" y="570" font-family="'Fira Sans', sans-serif" font-size="24" fill="rgba(255,255,255,0.8)" text-anchor="end">© 2025 AIKA World</text>

--- a/public/og/aikaworld-default-hu.svg
+++ b/public/og/aikaworld-default-hu.svg
@@ -17,8 +17,8 @@
   <rect width="1200" height="630" fill="url(#aikaWatermarkHu)" />
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', sans-serif" font-size="86" letter-spacing="0.32em" opacity="0.92">AIKA WORLD</text>
-    <text x="80" y="290" font-family="'Fira Sans', sans-serif" font-size="46" opacity="0.88">Anime co-op akció RPG</text>
-    <text x="80" y="360" font-family="'Fira Sans', sans-serif" font-size="30" opacity="0.75">Raid főellenfelek. Végtelen túlélés. Állítsd össze a csapatot.</text>
+    <text x="80" y="290" font-family="'Fira Sans', sans-serif" font-size="46" opacity="0.88">Történetközpontú anime akció RPG</text>
+    <text x="80" y="360" font-family="'Fira Sans', sans-serif" font-size="30" opacity="0.75">Szállj szembe az utolsó isten-géppel. Merülj egyedül.</text>
     <text x="80" y="430" font-family="'Fira Sans', sans-serif" font-size="26" opacity="0.65">Hivatalos közösségi előnézet beágyazott jogi metaadattal.</text>
   </g>
   <text x="1080" y="570" font-family="'Fira Sans', sans-serif" font-size="24" fill="rgba(255,255,255,0.8)" text-anchor="end">© 2025 AIKA World</text>

--- a/public/og/aikaworld-faq-en.svg
+++ b/public/og/aikaworld-faq-en.svg
@@ -17,7 +17,7 @@
   </g>
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">FAQ</text>
-    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Platforms, co-op, monetisation</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Platforms, story, monetisation</text>
     <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Get quick answers before diving into the world.</text>
   </g>
   <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">

--- a/public/og/aikaworld-faq-hu.svg
+++ b/public/og/aikaworld-faq-hu.svg
@@ -17,7 +17,7 @@
   </g>
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">GYIK</text>
-    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Platformok, coop, monetizáció</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Platformok, történet, monetizáció</text>
     <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Kapj gyors válaszokat, mielőtt belépsz a világba.</text>
   </g>
   <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">

--- a/public/og/aikaworld-home-en.svg
+++ b/public/og/aikaworld-home-en.svg
@@ -17,8 +17,8 @@
   </g>
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">AIKA WORLD</text>
-    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Anime co-op action RPG</text>
-    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Squad up for raids, survival and lore drops.</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Story-driven anime action RPG</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Descend through Elyndra's echoes and confront AIKA alone.</text>
   </g>
   <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
     <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>

--- a/public/og/aikaworld-home-hu.svg
+++ b/public/og/aikaworld-home-hu.svg
@@ -17,8 +17,8 @@
   </g>
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">AIKA WORLD</text>
-    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Anime kooperatív akció RPG</text>
-    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Alakíts csapatot rajtaütésekhez, túléléshez és történethez.</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Történetközpontú anime akció RPG</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Merülj Elyndra visszhangaiba, és egyedül állj AIKA elé.</text>
   </g>
   <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
     <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>

--- a/public/og/aikaworld-modes-en.svg
+++ b/public/og/aikaworld-modes-en.svg
@@ -17,8 +17,8 @@
   </g>
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Game Modes</text>
-    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Raid Boss & Infest Survival</text>
-    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Master mechanics, rotations and team roles.</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Story Chapters & Echo Challenges</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Master mechanics, pacing and resonance builds.</text>
   </g>
   <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
     <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>

--- a/public/og/aikaworld-modes-hu.svg
+++ b/public/og/aikaworld-modes-hu.svg
@@ -17,8 +17,8 @@
   </g>
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Játékmódok</text>
-    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Raid Boss & Infest Survival</text>
-    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Tanuld meg a mechanikákat és a csapat szerepeit.</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Történeti fejezetek & Visszhang kihívások</text>
+    <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Tanuld meg a mechanikákat, a tempót és a rezonancia összeállításokat.</text>
   </g>
   <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">
     <text font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="22">AIKA WORLD</text>

--- a/public/og/aikaworld-progression-en.svg
+++ b/public/og/aikaworld-progression-en.svg
@@ -17,7 +17,7 @@
   </g>
   <g fill="#ffffff">
     <text x="80" y="190" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="84" font-weight="700" letter-spacing="0.08em">Progression</text>
-    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Resonance, gear, hub</text>
+    <text x="80" y="270" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="48" font-weight="600" opacity="0.9">Resonance, gear, sanctum</text>
     <text x="80" y="340" font-family="'Fira Sans', 'Segoe UI', sans-serif" font-size="30" opacity="0.82">Unlock skills, craft builds and tune your hideout.</text>
   </g>
   <g transform="translate(80, 420)" fill="#ffffff" opacity="0.72">


### PR DESCRIPTION
## Summary
- rewrite English and Hungarian dictionary entries to remove multiplayer terminology and highlight the single-player story focus
- refresh share images, dev journal copy, and archived notes to align messaging across web previews
- adjust character bios and generated manifests to reflect the updated narrative framing

## Testing
- CI=1 npm run build
- npm run check:links *(fails: external fetch attempts are blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e646a49a88832581a72a530a3d564c