### PR TITLE
Enhance home page visuals with animated background and interactions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -17,6 +17,60 @@ body {
     color: #E6EDF7;
 }
 
+@keyframes aurora-glide {
+    0% {
+        background-position: 0% 50%;
+    }
+
+    100% {
+        background-position: 200% 50%;
+    }
+}
+
+.btn-aurora {
+    position: relative;
+    overflow: hidden;
+    border-radius: 9999px;
+    padding: 0.85rem 2.5rem;
+    font-size: 0.75rem;
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    font-weight: 700;
+    transition: transform 220ms ease, box-shadow 220ms ease;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.15), rgba(88, 207, 255, 0.65), rgba(255, 255, 255, 0.1));
+    background-size: 200% 100%;
+    box-shadow: 0 16px 35px -20px rgba(88, 207, 255, 0.75);
+}
+
+.btn-aurora::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.45), transparent);
+    transform: translateX(-120%);
+    transition: transform 260ms ease;
+}
+
+.btn-aurora:hover,
+.btn-aurora:focus-visible {
+    transform: translateY(-2px) scale(1.02);
+    animation: aurora-glide 1.6s linear infinite;
+    box-shadow: 0 20px 40px -18px rgba(88, 207, 255, 0.85);
+}
+
+.btn-aurora:hover::after,
+.btn-aurora:focus-visible::after {
+    transform: translateX(140%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .btn-aurora,
+    .btn-aurora::after {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
 a {
     text-decoration: none;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 export const runtime = 'edge';
 import './globals.css';
 import type { Metadata } from 'next';
+import Starfield from '../components/backgrounds/Starfield';
+import SmoothScrollProvider from '../components/providers/SmoothScrollProvider';
 import { resolveRequestLocale } from '../lib/i18n/server-locale';
 import { serverEnv } from '../lib/server-config';
 
@@ -31,7 +33,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           />
         )}
       </head>
-      <body className="min-h-dvh antialiased text-white">
+      <body className="min-h-dvh bg-[#05060a] font-sans antialiased text-white">
+        <SmoothScrollProvider />
+        <Starfield />
         {children}
       </body>
     </html>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -124,8 +124,10 @@ export default function Header({ steamUrl, discordUrl, locale, dictionary }: Hea
 
   return (
     <header
-      className={`fixed inset-x-0 top-0 z-50 border-b border-white/10 backdrop-blur transition-colors ${
-        isScrolled ? 'bg-black/60' : 'bg-black/20'
+      className={`fixed inset-x-0 top-0 z-50 border-b border-white/10 backdrop-blur transition-[background,box-shadow] duration-500 ${
+        isScrolled
+          ? 'bg-black/70 shadow-[0_18px_45px_-20px_rgba(79,70,229,0.75)]'
+          : 'bg-black/20 shadow-[0_10px_40px_-30px_rgba(79,70,229,0.45)]'
       }`}
     >
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import Link from 'next/link';
+import { motion, useReducedMotion } from 'framer-motion';
 import { FormEvent, useMemo, useState } from 'react';
 import type { Locale } from '../lib/i18n/config';
 import type { HomeDictionary, LightboxDictionary } from '../lib/i18n/types';
 import type { DevlogPostSummary } from '../lib/devlog';
 import Lightbox from './Lightbox';
 import Card from './ui/Card';
+import AnimatedHeading from './animations/AnimatedHeading';
+import ScrollReveal from './animations/ScrollReveal';
+import Section from './layout/Section';
 
 const factionIconClassNames = [
   'bg-accentA/15 text-accentA dark:bg-accentA/25',
@@ -55,6 +59,8 @@ export default function HomePage({
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
   const [feedback, setFeedback] = useState('');
+
+  const shouldReduceMotion = useReducedMotion();
 
   const basePath = useMemo(() => (locale === 'hu' ? '/hu' : ''), [locale]);
 
@@ -134,157 +140,201 @@ export default function HomePage({
   return (
     <div>
       {/* HERO */}
-      <section className="relative">
-        <div className="absolute inset-0 -z-10 bg-[radial-gradient(60%_50%_at_50%_0%,rgba(255,106,61,0.25),transparent_60%)]" />
-        <div className="mx-auto max-w-6xl px-4 py-24 md:py-32 text-center">
-          <h1 className="text-4xl md:text-6xl font-extrabold tracking-tight">
+      <section className="relative isolate overflow-hidden pb-28 pt-28 sm:pt-36">
+        <div className="pointer-events-none absolute inset-0 -z-20 bg-[radial-gradient(60%_70%_at_50%_-20%,rgba(118,75,162,0.45),transparent_70%)]" />
+        <div className="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(160deg,rgba(9,12,24,0.65)_0%,rgba(5,6,10,0.3)_45%,transparent_100%)]" />
+        <div className="mx-auto flex max-w-6xl flex-col items-center px-4 text-center">
+          <AnimatedHeading as="h1" className="text-4xl font-extrabold tracking-tight sm:text-5xl md:text-6xl">
             {dictionary.hero.tagline}
-          </h1>
-          <p className="mt-6 text-lg md:text-xl opacity-90 italic">
+          </AnimatedHeading>
+          <motion.p
+            className="mt-6 max-w-3xl text-lg italic text-white/80 md:text-xl"
+            initial={shouldReduceMotion ? false : { opacity: 0, y: 14 }}
+            animate={shouldReduceMotion ? false : { opacity: 1, y: 0 }}
+            transition={shouldReduceMotion ? undefined : { delay: 0.15, duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+          >
             {dictionary.hero.monologue}
-          </p>
-          <p className="mt-5 text-base md:text-lg text-slate-700 dark:text-slate-200">
+          </motion.p>
+          <motion.p
+            className="mt-5 max-w-2xl text-base text-white/75 md:text-lg"
+            initial={shouldReduceMotion ? false : { opacity: 0, y: 18 }}
+            animate={shouldReduceMotion ? false : { opacity: 1, y: 0 }}
+            transition={shouldReduceMotion ? undefined : { delay: 0.28, duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+          >
             {dictionary.hero.summary}
-          </p>
-          <div className="mt-8 flex justify-center">
-            <a className="px-5 py-3 rounded-lg bg-white/10 hover:bg-white/20 uppercase tracking-[0.2em] text-xs md:text-sm font-semibold" href="#newsletter">
+          </motion.p>
+          <motion.div
+            className="mt-10 flex justify-center"
+            initial={shouldReduceMotion ? false : { opacity: 0, scale: 0.94 }}
+            animate={shouldReduceMotion ? false : { opacity: 1, scale: 1 }}
+            transition={shouldReduceMotion ? undefined : { delay: 0.4, duration: 0.45, ease: [0.16, 1, 0.3, 1] }}
+          >
+            <a className="btn-aurora focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black" href="#newsletter">
               {dictionary.hero.primaryCta}
             </a>
-          </div>
-          <div className="mt-10 aspect-video w-full rounded-2xl overflow-hidden border border-white/10">
-            <video
-              className="h-full w-full object-cover"
-              autoPlay
-              muted
-              loop
-              playsInline
-              preload="none"
-              poster="https://media.aikaworld.com/teaser-poster.png"
-            >
-              <source src="https://media.aikaworld.com/teaser.webm" type="video/webm" />
-              <img
-                src="https://media.aikaworld.com/teaser-poster.png"
-                alt={dictionary.hero.videoPosterAlt}
+          </motion.div>
+          <ScrollReveal className="mt-14 w-full">
+            <div className="group relative aspect-video w-full overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-[0_45px_120px_-50px_rgba(124,58,237,0.65)]">
+              <div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-40" aria-hidden />
+              <video
                 className="h-full w-full object-cover"
-                loading="lazy"
-              />
-            </video>
-          </div>
+                autoPlay
+                muted
+                loop
+                playsInline
+                preload="none"
+                poster="https://media.aikaworld.com/teaser-poster.png"
+              >
+                <source src="https://media.aikaworld.com/teaser.webm" type="video/webm" />
+                <img
+                  src="https://media.aikaworld.com/teaser-poster.png"
+                  alt={dictionary.hero.videoPosterAlt}
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                />
+              </video>
+            </div>
+          </ScrollReveal>
         </div>
       </section>
 
       {/* WORLD & FACTIONS */}
-      <section id="world" className="mx-auto max-w-6xl px-4 py-16">
-        <h2 className="text-2xl md:text-3xl font-bold">{dictionary.world.title}</h2>
-        <p className="mt-3 opacity-90 max-w-3xl">{dictionary.world.intro}</p>
-        <div className="mt-8 grid gap-6 md:grid-cols-3">
+      <Section id="world">
+        <AnimatedHeading className="text-2xl font-bold sm:text-3xl">
+          {dictionary.world.title}
+        </AnimatedHeading>
+        <ScrollReveal delay={0.1} className="mt-4 max-w-3xl text-base text-white/75">
+          <p>{dictionary.world.intro}</p>
+        </ScrollReveal>
+        <div className="mt-10 grid gap-6 md:grid-cols-3">
           {dictionary.world.factions.map((faction, index) => {
             const iconClassName = factionIconClassNames[index % factionIconClassNames.length];
             const monogram = createMonogram(faction.name);
 
             return (
-              <Card key={faction.name}>
-                <Card.Title icon={monogram} iconClassName={iconClassName}>
-                  {faction.name}
-                </Card.Title>
-                <Card.Body>
-                  <p className="font-semibold text-accentB dark:text-accentB">{faction.tagline}</p>
-                  <ul className="list-disc list-inside space-y-2 text-sm leading-relaxed text-slate-600 dark:text-white/70 sm:text-base">
-                    {faction.bullets.map(bullet => (
-                      <li key={bullet}>{bullet}</li>
-                    ))}
-                  </ul>
-                </Card.Body>
-                <Card.Actions className="text-slate-900 dark:text-accentB">
-                  <Link
-                    href={resolveLocalizedHref(dictionary.world.ctaHref)}
-                    className="inline-flex items-center gap-2 text-inherit underline decoration-accentB decoration-2 underline-offset-4 hover:opacity-80"
-                  >
-                    {dictionary.world.ctaLabel}
-                    <span className="text-accentB dark:text-accentB" aria-hidden>
-                      →
-                    </span>
-                  </Link>
-                </Card.Actions>
-              </Card>
+              <ScrollReveal key={faction.name} delay={index * 0.12} className="h-full">
+                <Card className="group h-full backdrop-blur-sm transition-transform duration-500 hover:-translate-y-2 hover:shadow-[0_35px_90px_-50px_rgba(124,58,237,0.85)]">
+                  <Card.Title icon={monogram} iconClassName={iconClassName}>
+                    {faction.name}
+                  </Card.Title>
+                  <Card.Body>
+                    <p className="font-semibold text-accentB dark:text-accentB">{faction.tagline}</p>
+                    <ul className="list-disc list-inside space-y-2 text-sm leading-relaxed text-slate-600 dark:text-white/70 sm:text-base">
+                      {faction.bullets.map(bullet => (
+                        <li key={bullet}>{bullet}</li>
+                      ))}
+                    </ul>
+                  </Card.Body>
+                  <Card.Actions className="text-slate-900 dark:text-accentB">
+                    <Link
+                      href={resolveLocalizedHref(dictionary.world.ctaHref)}
+                      className="inline-flex items-center gap-2 text-inherit underline decoration-accentB decoration-2 underline-offset-4 transition hover:translate-x-[2px] hover:opacity-90"
+                    >
+                      {dictionary.world.ctaLabel}
+                      <span className="text-accentB dark:text-accentB" aria-hidden>
+                        →
+                      </span>
+                    </Link>
+                  </Card.Actions>
+                </Card>
+              </ScrollReveal>
             );
           })}
         </div>
-      </section>
+      </Section>
 
       {/* MODES */}
-      <section id="modes" className="mx-auto max-w-6xl px-4 py-16">
-        <h2 className="text-2xl md:text-3xl font-bold">{dictionary.modes.title}</h2>
-        <div className="mt-6 grid md:grid-cols-2 gap-6">
-          {dictionary.modes.cards.map(card => (
-            <div key={card.title} className="rounded-xl border border-white/10 p-6 bg-white/5 flex flex-col">
-              <h3 className="text-xl font-semibold">{card.title}</h3>
-              {card.subtitle ? <p className="mt-1 text-sm uppercase tracking-wide opacity-70">{card.subtitle}</p> : null}
-              {card.body || card.description ? (
-                <p className="mt-2 opacity-90">{card.body ?? card.description}</p>
-              ) : null}
-              {card.points?.length ? (
-                <ul className="mt-4 list-disc list-inside opacity-80 text-sm">
-                  {card.points.map(point => (
-                    <li key={point}>{point}</li>
-                  ))}
-                </ul>
-              ) : null}
-              {card.linkLabel && card.href ? (
-                <Link
-                  href={card.href}
-                  className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-accentB hover:opacity-80"
-                >
-                  {card.linkLabel}
-                  <span aria-hidden>→</span>
-                </Link>
-              ) : null}
-            </div>
+      <Section id="modes" tone="neutral">
+        <AnimatedHeading className="text-2xl font-bold sm:text-3xl">
+          {dictionary.modes.title}
+        </AnimatedHeading>
+        <div className="mt-8 grid gap-6 md:grid-cols-2">
+          {dictionary.modes.cards.map((card, index) => (
+            <ScrollReveal key={card.title} delay={index * 0.15} className="h-full">
+              <div className="flex h-full flex-col rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm transition-transform duration-500 hover:-translate-y-1.5 hover:shadow-[0_35px_90px_-50px_rgba(59,130,246,0.55)]">
+                <AnimatedHeading as="h3" className="text-xl font-semibold">
+                  {card.title}
+                </AnimatedHeading>
+                {card.subtitle ? (
+                  <p className="mt-1 text-xs uppercase tracking-[0.26em] text-white/60">{card.subtitle}</p>
+                ) : null}
+                {card.body || card.description ? (
+                  <p className="mt-3 text-sm text-white/75 md:text-base">{card.body ?? card.description}</p>
+                ) : null}
+                {card.points?.length ? (
+                  <ul className="mt-4 list-disc list-inside space-y-2 text-sm text-white/70">
+                    {card.points.map(point => (
+                      <li key={point}>{point}</li>
+                    ))}
+                  </ul>
+                ) : null}
+                {card.linkLabel && card.href ? (
+                  <Link
+                    href={card.href}
+                    className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-accentB transition hover:translate-x-[2px] hover:opacity-90"
+                  >
+                    {card.linkLabel}
+                    <span aria-hidden>→</span>
+                  </Link>
+                ) : null}
+              </div>
+            </ScrollReveal>
           ))}
         </div>
-      </section>
+      </Section>
 
       {/* CHARACTERS */}
-      <section id="characters" className="mx-auto max-w-6xl px-4 py-16">
-        <h2 className="text-2xl md:text-3xl font-bold">{dictionary.characters.title}</h2>
-        <p className="mt-2 opacity-90">{dictionary.characters.description}</p>
-        <div className="mt-6 grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-          {dictionary.characters.cards.map(character => (
-            <Link
-              key={character.slug}
-              href={`${basePath}/characters/${character.slug}`}
-              className="rounded-xl border border-white/10 p-4 bg-white/5 hover:bg-white/10 transition"
-            >
-              <div className={`h-36 w-full rounded-lg bg-${character.color}`} />
-              <div className="mt-3 font-semibold">{character.name}</div>
-              <div className="text-sm opacity-80">{character.element}</div>
-            </Link>
+      <Section id="characters">
+        <AnimatedHeading className="text-2xl font-bold sm:text-3xl">
+          {dictionary.characters.title}
+        </AnimatedHeading>
+        <ScrollReveal delay={0.1} className="mt-3 max-w-3xl text-base text-white/75">
+          <p>{dictionary.characters.description}</p>
+        </ScrollReveal>
+        <div className="mt-8 grid gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5">
+          {dictionary.characters.cards.map((character, index) => (
+            <ScrollReveal key={character.slug} delay={index * 0.08} className="h-full">
+              <Link
+                href={`${basePath}/characters/${character.slug}`}
+                className="group block h-full rounded-2xl border border-white/10 bg-white/5 p-4 transition-transform duration-500 hover:-translate-y-1.5 hover:shadow-[0_35px_90px_-60px_rgba(236,72,153,0.7)]"
+              >
+                <div className={`h-36 w-full rounded-xl bg-${character.color}`} />
+                <div className="mt-4 font-semibold text-white">{character.name}</div>
+                <div className="text-sm text-white/70">{character.element}</div>
+              </Link>
+            </ScrollReveal>
           ))}
         </div>
-      </section>
+      </Section>
 
       {/* MEDIA */}
-      <section id="media" className="mx-auto max-w-6xl px-4 py-16">
-        <h2 className="text-2xl md:text-3xl font-bold">{dictionary.media.title}</h2>
-        <p className="mt-2 opacity-90">{dictionary.media.description}</p>
-        <div className="mt-6 grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+      <Section id="media" tone="neutral">
+        <AnimatedHeading className="text-2xl font-bold sm:text-3xl">
+          {dictionary.media.title}
+        </AnimatedHeading>
+        <ScrollReveal delay={0.1} className="mt-3 max-w-3xl text-base text-white/75">
+          <p>{dictionary.media.description}</p>
+        </ScrollReveal>
+        <div className="mt-8 grid gap-5 sm:grid-cols-2 md:grid-cols-3">
           {dictionary.media.images.map((image, index) => (
-            <button
-              key={image.src}
-              type="button"
-              onClick={() => openLightbox(index)}
-              className="group relative overflow-hidden rounded-lg border border-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB"
-            >
-              <img
-                className="h-full w-full object-cover transition duration-150 group-hover:scale-105"
-                src={image.src}
-                alt={image.alt}
-                loading="lazy"
-              />
-            </button>
+            <ScrollReveal key={image.src} delay={index * 0.08} className="h-full">
+              <button
+                type="button"
+                onClick={() => openLightbox(index)}
+                className="group relative block h-full overflow-hidden rounded-2xl border border-white/10 bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+              >
+                <span className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.35),transparent_55%)] opacity-0 transition-opacity duration-300 group-hover:opacity-100" aria-hidden />
+                <img
+                  className="h-full w-full object-cover transition duration-300 group-hover:scale-110"
+                  src={image.src}
+                  alt={image.alt}
+                  loading="lazy"
+                />
+              </button>
+            </ScrollReveal>
           ))}
         </div>
-      </section>
+      </Section>
 
       <Lightbox
         images={dictionary.media.images}
@@ -295,75 +345,90 @@ export default function HomePage({
       />
 
       {/* ROADMAP */}
-      <section id="roadmap" className="mx-auto max-w-6xl px-4 py-16">
-        <h2 className="text-2xl md:text-3xl font-bold">{dictionary.roadmap.title}</h2>
-        <ol className="mt-6 relative border-s border-white/10 ps-6">
+      <Section id="roadmap">
+        <AnimatedHeading className="text-2xl font-bold sm:text-3xl">
+          {dictionary.roadmap.title}
+        </AnimatedHeading>
+        <ol className="relative mt-10 border-s border-white/15 ps-6">
           {[dictionary.roadmap.phase1, dictionary.roadmap.phase2, dictionary.roadmap.phase3].map((phase, index) => (
-            <li key={phase.title} className="mb-6 last:mb-0">
-              <div
-                className={`absolute -start-[6px] mt-1.5 h-3 w-3 rounded-full ${
-                  ['bg-accentA', 'bg-accentD', 'bg-accentB'][index % 3]
-                }`}
-              />
-              <h3 className="font-semibold">{phase.title}</h3>
-              <p className="opacity-80 text-sm">{phase.body}</p>
-            </li>
+            <ScrollReveal key={phase.title} delay={index * 0.12}>
+              <li className="relative mb-8 last:mb-0">
+                <div
+                  className={`absolute -start-[10px] top-1.5 h-3 w-3 rounded-full shadow-[0_0_20px_rgba(96,165,250,0.7)] ${
+                    ['bg-accentA', 'bg-accentD', 'bg-accentB'][index % 3]
+                  }`}
+                />
+                <AnimatedHeading as="h3" className="text-lg font-semibold">
+                  {phase.title}
+                </AnimatedHeading>
+                <p className="mt-2 text-sm text-white/75">{phase.body}</p>
+              </li>
+            </ScrollReveal>
           ))}
         </ol>
-      </section>
+      </Section>
 
       {/* DEVLOG TEASERS */}
-      <section className="mx-auto max-w-6xl px-4 py-16">
+      <Section>
         <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-          <div className="max-w-3xl space-y-3">
-            <h2 className="text-2xl md:text-3xl font-bold">{dictionary.devlog.title}</h2>
-            <p className="text-sm md:text-base opacity-90">{dictionary.devlog.description}</p>
-          </div>
-          <Link
-            href={resolveLocalizedHref('/dev-journal')}
-            className="inline-flex items-center gap-2 self-start rounded-full border border-white/20 px-4 py-2 text-sm font-semibold hover:bg-white/10"
-          >
-            {dictionary.devlog.viewAllLabel}
-            <span aria-hidden>→</span>
-          </Link>
+          <ScrollReveal className="max-w-3xl space-y-3">
+            <AnimatedHeading className="text-2xl font-bold sm:text-3xl">
+              {dictionary.devlog.title}
+            </AnimatedHeading>
+            <p className="text-sm text-white/75 md:text-base">{dictionary.devlog.description}</p>
+          </ScrollReveal>
+          <ScrollReveal delay={0.15}>
+            <Link
+              href={resolveLocalizedHref('/dev-journal')}
+              className="inline-flex items-center gap-2 self-start rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-white transition hover:translate-x-[2px] hover:border-white/40 hover:bg-white/10"
+            >
+              {dictionary.devlog.viewAllLabel}
+              <span aria-hidden>→</span>
+            </Link>
+          </ScrollReveal>
         </div>
 
         {hasDevlogPosts && (
-          <div className="mt-10 grid gap-6 md:grid-cols-2">
-            {devlogPosts.map(post => (
-              <article
-                key={post.slug}
-                className="flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/5 shadow-lg shadow-black/20"
-              >
-                <div className="aspect-[16/9] w-full overflow-hidden">
-                  <img src={post.cover} alt={post.title} className="h-full w-full object-cover" loading="lazy" />
-                </div>
-                <div className="flex flex-1 flex-col gap-4 p-6">
-                  <time className="text-xs uppercase tracking-wide text-white/60" dateTime={post.date}>
-                    {post.date}
-                  </time>
-                  <h3 className="text-xl font-semibold">{post.title}</h3>
-                  <p className="text-sm md:text-base opacity-80">{post.summary}</p>
-                  <Link
-                    href={resolveLocalizedHref(`/dev-journal/${post.slug}`)}
-                    className="mt-auto inline-flex items-center gap-2 text-sm font-semibold text-accentB hover:opacity-80"
-                  >
-                    {dictionary.devlog.readMoreLabel}
-                    <span aria-hidden>→</span>
-                  </Link>
-                </div>
-              </article>
+          <div className="mt-12 grid gap-6 md:grid-cols-2">
+            {devlogPosts.map((post, index) => (
+              <ScrollReveal key={post.slug} delay={index * 0.12} className="h-full">
+                <article className="flex h-full flex-col overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-[0_45px_120px_-60px_rgba(30,64,175,0.65)]">
+                  <div className="aspect-[16/9] w-full overflow-hidden">
+                    <img src={post.cover} alt={post.title} className="h-full w-full object-cover transition duration-500 hover:scale-105" loading="lazy" />
+                  </div>
+                  <div className="flex flex-1 flex-col gap-4 p-6">
+                    <time className="text-xs uppercase tracking-[0.28em] text-white/60" dateTime={post.date}>
+                      {post.date}
+                    </time>
+                    <AnimatedHeading as="h3" className="text-xl font-semibold">
+                      {post.title}
+                    </AnimatedHeading>
+                    <p className="text-sm text-white/75 md:text-base">{post.summary}</p>
+                    <Link
+                      href={resolveLocalizedHref(`/dev-journal/${post.slug}`)}
+                      className="mt-auto inline-flex items-center gap-2 text-sm font-semibold text-accentB transition hover:translate-x-[2px] hover:opacity-90"
+                    >
+                      {dictionary.devlog.readMoreLabel}
+                      <span aria-hidden>→</span>
+                    </Link>
+                  </div>
+                </article>
+              </ScrollReveal>
             ))}
           </div>
         )}
-      </section>
+      </Section>
 
       {/* COMMUNITY / NEWSLETTER */}
-      <section id="community" className="mx-auto max-w-6xl px-4 py-16">
-        <h2 className="text-2xl md:text-3xl font-bold">{dictionary.community.title}</h2>
-        <p className="mt-2 opacity-90">{dictionary.community.description}</p>
+      <Section id="community" tone="primary">
+        <AnimatedHeading className="text-2xl font-bold sm:text-3xl">
+          {dictionary.community.title}
+        </AnimatedHeading>
+        <ScrollReveal delay={0.1} className="mt-3 max-w-3xl text-base text-white/75">
+          <p>{dictionary.community.description}</p>
+        </ScrollReveal>
 
-        <div className="mt-8 grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3">
+        <div className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2 xl:grid-cols-3">
           {dictionary.community.cards.map((card, index) => {
             const href = resolveLocalizedHref(card.ctaHref);
             const iconConfig = communityIconStyles[card.id] ?? {
@@ -372,88 +437,96 @@ export default function HomePage({
             };
 
             return (
-              <Card key={card.id}>
-                <Card.Title
-                  eyebrow={card.eyebrow}
-                  icon={iconConfig.label}
-                  iconClassName={iconConfig.className}
-                >
-                  {card.title}
-                </Card.Title>
-                <Card.Body>
-                  <p>{card.description}</p>
-                </Card.Body>
-                <Card.Actions className="flex-col items-start gap-2 text-accentB dark:text-accentB">
-                  <a
-                    href={href}
-                    className="inline-flex items-center justify-center gap-2 rounded-full bg-accentB px-4 py-2 text-sm text-black transition hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#05060a]"
+              <ScrollReveal key={card.id} delay={index * 0.12} className="h-full">
+                <Card className="h-full backdrop-blur-sm transition-transform duration-500 hover:-translate-y-2 hover:shadow-[0_35px_90px_-55px_rgba(34,211,238,0.75)]">
+                  <Card.Title
+                    eyebrow={card.eyebrow}
+                    icon={iconConfig.label}
+                    iconClassName={iconConfig.className}
                   >
-                    {card.ctaLabel}
-                    <span aria-hidden>→</span>
-                  </a>
-                  {card.note ? (
-                    <p className="text-xs font-normal text-slate-500 dark:text-white/60">{card.note}</p>
-                  ) : null}
-                </Card.Actions>
-              </Card>
+                    {card.title}
+                  </Card.Title>
+                  <Card.Body>
+                    <p>{card.description}</p>
+                  </Card.Body>
+                  <Card.Actions className="flex-col items-start gap-2 text-accentB dark:text-accentB">
+                    <a
+                      href={href}
+                      className="inline-flex items-center justify-center gap-2 rounded-full bg-accentB px-4 py-2 text-sm text-black transition hover:-translate-y-[1px] hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accentB focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#05060a]"
+                    >
+                      {card.ctaLabel}
+                      <span aria-hidden>→</span>
+                    </a>
+                    {card.note ? (
+                      <p className="text-xs font-normal text-white/60">{card.note}</p>
+                    ) : null}
+                  </Card.Actions>
+                </Card>
+              </ScrollReveal>
             );
           })}
         </div>
 
-        <div id="community-newsletter" className="mt-12 max-w-xl">
-          <h3 className="text-xl font-semibold">{dictionary.community.newsletterTitle}</h3>
-          <p className="mt-2 text-sm md:text-base opacity-80">
-            {dictionary.community.newsletterDescription}
-          </p>
+        <div id="community-newsletter" className="mt-14 max-w-xl">
+          <ScrollReveal delay={0.2} className="space-y-3">
+            <AnimatedHeading as="h3" className="text-xl font-semibold">
+              {dictionary.community.newsletterTitle}
+            </AnimatedHeading>
+            <p className="text-sm text-white/70 md:text-base">{dictionary.community.newsletterDescription}</p>
+          </ScrollReveal>
         </div>
 
-        <form id="newsletter" className="mt-6 max-w-md" onSubmit={handleSubmit}>
-          <label className="block text-sm mb-2">{dictionary.newsletter.emailLabel}</label>
-          <div className="flex gap-2">
-            <input
-              required
-              type="email"
-              placeholder={dictionary.newsletter.emailPlaceholder}
-              className="w-full px-3 py-2 rounded-md bg-white/10 border border-white/10 outline-none"
-              value={email}
-              onChange={event => {
-                setEmail(event.target.value);
-                if (status !== 'idle') {
-                  setStatus('idle');
-                  setFeedback('');
-                }
-              }}
-              disabled={status === 'loading'}
-            />
-            <button
-              type="submit"
-              className="px-4 rounded-md bg-accentB hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
-              disabled={status === 'loading'}
-            >
-              {status === 'loading' ? dictionary.newsletter.submitLoading : dictionary.newsletter.submitIdle}
-            </button>
-          </div>
-          <p className="mt-2 text-xs opacity-70">
-            {dictionary.newsletter.consentPrefix}
-            <Link
-              href={`${basePath}/privacy`}
-              className="underline decoration-dotted underline-offset-2 hover:text-accentB"
-            >
-              {dictionary.newsletter.consentLinkLabel}
-            </Link>
-            {dictionary.newsletter.consentSuffix}
-          </p>
-          {feedback && (
-            <p
-              className={`mt-3 text-sm ${status === 'success' ? 'text-emerald-300' : 'text-rose-300'}`}
-              role="status"
-              aria-live="polite"
-            >
-              {feedback}
+        <ScrollReveal delay={0.3}>
+          <form id="newsletter" className="mt-6 max-w-md rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm" onSubmit={handleSubmit}>
+            <label className="block text-sm font-semibold tracking-[0.2em] text-white/70">
+              {dictionary.newsletter.emailLabel}
+            </label>
+            <div className="mt-3 flex gap-2">
+              <input
+                required
+                type="email"
+                placeholder={dictionary.newsletter.emailPlaceholder}
+                className="w-full rounded-xl border border-white/15 bg-black/30 px-3 py-2 text-sm text-white/90 outline-none transition focus:border-accentB focus:ring-1 focus:ring-accentB"
+                value={email}
+                onChange={event => {
+                  setEmail(event.target.value);
+                  if (status !== 'idle') {
+                    setStatus('idle');
+                    setFeedback('');
+                  }
+                }}
+                disabled={status === 'loading'}
+              />
+              <button
+                type="submit"
+                className="btn-aurora px-6 py-2 text-xs"
+                disabled={status === 'loading'}
+              >
+                {status === 'loading' ? dictionary.newsletter.submitLoading : dictionary.newsletter.submitIdle}
+              </button>
+            </div>
+            <p className="mt-3 text-xs text-white/60">
+              {dictionary.newsletter.consentPrefix}
+              <Link
+                href={`${basePath}/privacy`}
+                className="underline decoration-dotted underline-offset-4 hover:text-accentB"
+              >
+                {dictionary.newsletter.consentLinkLabel}
+              </Link>
+              {dictionary.newsletter.consentSuffix}
             </p>
-          )}
-        </form>
-      </section>
+            {feedback && (
+              <p
+                className={`mt-4 text-sm ${status === 'success' ? 'text-emerald-300' : 'text-rose-300'}`}
+                role="status"
+                aria-live="polite"
+              >
+                {feedback}
+              </p>
+            )}
+          </form>
+        </ScrollReveal>
+      </Section>
     </div>
   );
 }

--- a/components/SiteLayout.tsx
+++ b/components/SiteLayout.tsx
@@ -4,6 +4,7 @@ import type { Locale } from '../lib/i18n/config';
 import { serverEnv } from '../lib/server-config';
 import type { Dictionary } from '../lib/i18n/types';
 import { buildInfo } from '../lib/generated/build-info';
+import PageTransition from './animations/PageTransition';
 import Header from './Header';
 
 type SiteLayoutProps = {
@@ -58,7 +59,9 @@ export default function SiteLayout({ locale, dictionary, children }: SiteLayoutP
         locale={locale}
         dictionary={dictionary.header}
       />
-      <main className="pt-14">{children}</main>
+      <main className="pt-14">
+        <PageTransition>{children}</PageTransition>
+      </main>
       <footer className="mt-24 border-t border-white/10">
         <div className="mx-auto max-w-5xl px-4 py-12 text-sm">
           <div className="grid gap-10 md:grid-cols-3">

--- a/components/animations/AnimatedHeading.tsx
+++ b/components/animations/AnimatedHeading.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+
+const headingMap = {
+  h1: motion.h1,
+  h2: motion.h2,
+  h3: motion.h3
+};
+
+type HeadingTag = keyof typeof headingMap;
+
+type AnimatedHeadingProps = {
+  as?: HeadingTag;
+  className?: string;
+  children: ReactNode;
+  delay?: number;
+};
+
+export default function AnimatedHeading({ as = 'h2', className, children, delay = 0 }: AnimatedHeadingProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const Component = headingMap[as];
+
+  if (shouldReduceMotion) {
+    return createElement(as, { className }, children);
+  }
+
+  return (
+    <Component
+      className={className}
+      initial={{ opacity: 0, letterSpacing: '0.12em', y: 20 }}
+      whileInView={{ opacity: 1, letterSpacing: 'normal', y: 0 }}
+      transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1], delay }}
+      viewport={{ once: true, amount: 0.6 }}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/components/animations/PageTransition.tsx
+++ b/components/animations/PageTransition.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+export default function PageTransition({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0, y: 24 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -24 }}
+        transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        className="min-h-[calc(100dvh-3.5rem)]"
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/components/animations/ScrollReveal.tsx
+++ b/components/animations/ScrollReveal.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { motion, useReducedMotion, useInView } from 'framer-motion';
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+
+type ScrollRevealProps = {
+  children: ReactNode;
+  delay?: number;
+  className?: string;
+  once?: boolean;
+};
+
+export default function ScrollReveal({ children, delay = 0, className, once = true }: ScrollRevealProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const ref = useRef<HTMLDivElement | null>(null);
+  const isInView = useInView(ref, { margin: '0px 0px -15% 0px', once });
+  const [hasBeenInView, setHasBeenInView] = useState(false);
+
+  useEffect(() => {
+    if (isInView) {
+      setHasBeenInView(true);
+    }
+  }, [isInView]);
+
+  if (shouldReduceMotion) {
+    return (
+      <div ref={ref} className={className}>
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <motion.div
+      ref={ref}
+      className={className}
+      style={{ transformOrigin: 'top center' }}
+      initial={{ opacity: 0, y: 40, rotateX: 6 }}
+      animate={isInView || hasBeenInView ? { opacity: 1, y: 0, rotateX: 0 } : undefined}
+      transition={{ delay, duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/backgrounds/Starfield.tsx
+++ b/components/backgrounds/Starfield.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const STAR_COUNT = 140;
+const MAX_STAR_SIZE = 2.2;
+const STAR_SPEED = 0.04;
+
+const createStar = (width: number, height: number) => ({
+  x: Math.random() * width,
+  y: Math.random() * height,
+  radius: Math.random() * MAX_STAR_SIZE + 0.2,
+  velocity: Math.random() * STAR_SPEED + STAR_SPEED * 0.6
+});
+
+export default function Starfield() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext('2d');
+
+    if (!canvas || !context) {
+      return;
+    }
+
+    const resetCanvas = () => {
+      context.setTransform(1, 0, 0, 1, 0, 0);
+      canvas.width = canvas.clientWidth;
+      canvas.height = canvas.clientHeight;
+    };
+
+    resetCanvas();
+
+    if (prefersReducedMotion) {
+      context.clearRect(0, 0, canvas.width, canvas.height);
+      context.fillStyle = 'rgba(255,255,255,0.06)';
+      for (let index = 0; index < STAR_COUNT / 4; index += 1) {
+        const x = Math.random() * canvas.width;
+        const y = Math.random() * canvas.height;
+        const radius = Math.random() * MAX_STAR_SIZE * 0.8 + 0.2;
+        context.beginPath();
+        context.arc(x, y, radius, 0, Math.PI * 2);
+        context.fill();
+      }
+      return;
+    }
+
+    let animationFrameId = 0;
+    let width = canvas.clientWidth;
+    let height = canvas.clientHeight;
+
+    const resizeCanvas = () => {
+      width = canvas.clientWidth;
+      height = canvas.clientHeight;
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      context.setTransform(1, 0, 0, 1, 0, 0);
+      context.scale(dpr, dpr);
+    };
+
+    resizeCanvas();
+
+    let stars = Array.from({ length: STAR_COUNT }, () => createStar(width, height));
+
+    const render = () => {
+      context.clearRect(0, 0, width, height);
+      context.fillStyle = 'rgba(255,255,255,0.8)';
+
+      for (const star of stars) {
+        star.y += star.velocity;
+        if (star.y > height) {
+          star.x = Math.random() * width;
+          star.y = -star.radius;
+          star.velocity = Math.random() * STAR_SPEED + STAR_SPEED * 0.6;
+        }
+
+        context.globalAlpha = 0.35 + Math.random() * 0.4;
+        context.beginPath();
+        context.arc(star.x, star.y, star.radius, 0, Math.PI * 2);
+        context.fill();
+      }
+
+      animationFrameId = window.requestAnimationFrame(render);
+    };
+
+    const handleResize = () => {
+      context.setTransform(1, 0, 0, 1, 0, 0);
+      resizeCanvas();
+      stars = Array.from({ length: STAR_COUNT }, () => createStar(width, height));
+    };
+
+    animationFrameId = window.requestAnimationFrame(render);
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      window.cancelAnimationFrame(animationFrameId);
+    };
+  }, [prefersReducedMotion]);
+
+  return (
+    <canvas
+      aria-hidden
+      ref={canvasRef}
+      className="pointer-events-none fixed inset-0 -z-50 h-full w-full bg-[radial-gradient(circle_at_center,rgba(74,41,115,0.25)_0%,rgba(5,6,10,0.95)_55%,rgba(0,0,0,1)_100%)]"
+    />
+  );
+}

--- a/components/layout/Section.tsx
+++ b/components/layout/Section.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+
+function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}
+
+type SectionProps = {
+  id?: string;
+  tone?: 'primary' | 'neutral';
+  children: ReactNode;
+  className?: string;
+};
+
+export default function Section({ id, tone = 'primary', children, className }: SectionProps) {
+  const toneClass =
+    tone === 'primary'
+      ? 'before:from-accentB/15 before:via-transparent after:bg-gradient-to-b after:from-accentB/10 after:via-transparent after:to-transparent'
+      : 'before:from-white/12 before:via-transparent after:bg-gradient-to-b after:from-white/8 after:via-transparent after:to-transparent';
+
+  return (
+    <section
+      id={id}
+      className={cn(
+        'relative isolate overflow-hidden py-20 sm:py-24',
+        'before:pointer-events-none before:absolute before:inset-x-12 before:-top-24 before:h-48 before:-skew-y-6 before:rounded-[4rem] before:bg-gradient-to-br before:blur-3xl before:content-[""]',
+        'after:pointer-events-none after:absolute after:-bottom-24 after:left-0 after:right-0 after:h-32 after:skew-y-6 after:opacity-80 after:blur-3xl after:content-[""]',
+        toneClass,
+        className
+      )}
+    >
+      <div className="mx-auto max-w-6xl px-4">{children}</div>
+    </section>
+  );
+}

--- a/components/providers/SmoothScrollProvider.tsx
+++ b/components/providers/SmoothScrollProvider.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const HEADER_OFFSET = 72;
+
+function easeOutBack(progress: number) {
+  const c1 = 1.70158;
+  const c3 = c1 + 1;
+  return 1 + c3 * Math.pow(progress - 1, 3) + c1 * Math.pow(progress - 1, 2);
+}
+
+export default function SmoothScrollProvider() {
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    if (mediaQuery.matches) {
+      return;
+    }
+
+    let animationFrame = 0;
+
+    const cancelAnimation = () => {
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame);
+        animationFrame = 0;
+      }
+    };
+
+    const animateScroll = (targetY: number) => {
+      const startY = window.scrollY;
+      const distance = targetY - startY;
+      const duration = Math.min(900, Math.max(450, Math.abs(distance) * 0.6));
+      const startTime = performance.now();
+
+      const tick = (now: number) => {
+        const elapsed = now - startTime;
+        const progress = Math.min(1, elapsed / duration);
+        const eased = easeOutBack(progress);
+        window.scrollTo({ top: startY + distance * eased });
+        if (progress < 1) {
+          animationFrame = window.requestAnimationFrame(tick);
+        }
+      };
+
+      animationFrame = window.requestAnimationFrame(tick);
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (!target) {
+        return;
+      }
+
+      const anchor = target.closest('a[href^="#"]') as HTMLAnchorElement | null;
+      if (!anchor || anchor.getAttribute('href') === '#') {
+        return;
+      }
+
+      const url = new URL(anchor.href, window.location.href);
+      if (url.pathname !== window.location.pathname) {
+        return;
+      }
+
+      const id = decodeURIComponent(url.hash.replace(/^#/, ''));
+      if (!id) {
+        return;
+      }
+
+      const destination = document.getElementById(id);
+      if (!destination) {
+        return;
+      }
+
+      event.preventDefault();
+      cancelAnimation();
+
+      const rect = destination.getBoundingClientRect();
+      const targetY = rect.top + window.scrollY - HEADER_OFFSET;
+      animateScroll(targetY);
+
+      window.history.pushState({}, '', `#${id}`);
+      window.requestAnimationFrame(() => destination.focus({ preventScroll: true }));
+    };
+
+    document.addEventListener('click', handleClick, { passive: false });
+
+    return () => {
+      cancelAnimation();
+      document.removeEventListener('click', handleClick);
+    };
+  }, []);
+
+  return null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.1.0",
             "license": "MIT",
             "dependencies": {
+                "framer-motion": "^12.23.22",
                 "gray-matter": "^4.0.3",
                 "next": "^15.0.0",
                 "react": "18.3.1",
@@ -4793,6 +4794,33 @@
                 "url": "https://github.com/sponsors/rawify"
             }
         },
+        "node_modules/framer-motion": {
+            "version": "12.23.22",
+            "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.22.tgz",
+            "integrity": "sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-dom": "^12.23.21",
+                "motion-utils": "^12.23.6",
+                "tslib": "^2.4.0"
+            },
+            "peerDependencies": {
+                "@emotion/is-prop-valid": "*",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@emotion/is-prop-valid": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -6349,6 +6377,21 @@
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
             "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/motion-dom": {
+            "version": "12.23.21",
+            "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.21.tgz",
+            "integrity": "sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "motion-utils": "^12.23.6"
+            }
+        },
+        "node_modules/motion-utils": {
+            "version": "12.23.6",
+            "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+            "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
             "license": "MIT"
         },
         "node_modules/mri": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "export:cf": "npx vercel build && node ./scripts/patch-vercel-output.mjs && npx @cloudflare/next-on-pages@1 --skip-build"
     },
     "dependencies": {
+        "framer-motion": "^12.23.22",
         "gray-matter": "^4.0.3",
         "next": "^15.0.0",
         "react": "18.3.1",
@@ -29,12 +30,12 @@
     },
     "devDependencies": {
         "@cloudflare/next-on-pages": "^1.13.16",
+        "@playwright/test": "1.55.1",
         "@types/node": "^24.6.0",
         "@types/react": "^19.1.16",
         "autoprefixer": "10.4.20",
         "fast-xml-parser": "4.5.0",
         "linkinator": "6.1.2",
-        "@playwright/test": "1.55.1",
         "pa11y": "6.2.3",
         "postcss": "8.4.47",
         "tailwindcss": "3.4.13",


### PR DESCRIPTION
## Summary
- add a reusable starfield background and smooth scrolling provider to refine the global atmosphere
- introduce animated headings, section wrappers, and scroll reveal utilities to refresh the home page presentation
- update hero, cards, and calls-to-action with modern hover/transition effects and enable page-level motion transitions

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e657a4f2708325a53266a70c0a24cf