### PR TITLE
Rewrite progression page with resonance-focused narrative

### DIFF
--- a/app/(marketing)/progression/page.tsx
+++ b/app/(marketing)/progression/page.tsx
@@ -4,6 +4,7 @@ import { getDictionary } from '../../../lib/i18n/dictionaries';
 import { resolveRequestLocale } from '../../../lib/i18n/server-locale';
 import { createStaticPageMetadata } from '../../../lib/seo';
 import { locales } from '../../../lib/i18n/config';
+import { getProgressionContent } from '../../../lib/content/progression';
 
 export function generateStaticParams(): Record<string, never>[] {
   return locales.map(() => ({}));
@@ -19,6 +20,7 @@ export default async function ProgressionPage() {
   const locale = await resolveRequestLocale();
   const dictionary = getDictionary(locale);
   const { title, body } = dictionary.progression;
+  const progressionContent = await getProgressionContent(locale);
 
   return (
     <SiteLayout locale={locale} dictionary={dictionary}>
@@ -27,6 +29,10 @@ export default async function ProgressionPage() {
           <h1 className="text-3xl md:text-4xl font-bold">{title}</h1>
           <p className="text-base md:text-lg opacity-90">{body}</p>
         </header>
+        <article
+          className="space-y-6 text-sm leading-relaxed text-white/80 md:text-base"
+          dangerouslySetInnerHTML={{ __html: progressionContent }}
+        />
       </div>
     </SiteLayout>
   );

--- a/content/progression.md
+++ b/content/progression.md
@@ -1,0 +1,39 @@
+<!-- EN -->
+*“Growth is not strength. It’s remembering what you were before.”*
+
+**Resonance Synchrony**
+Every city you cross, every Core you cradle back into place changes the frequency of Elyndra. Progression is not ascent; it is the slow alignment of your pulse with AIKA’s forgotten rhythm.
+
+**Core Echoes**
+After each chapter the world offers a new Core, and with it a shift in resonance. Streets re-tone, allies speak in different cadences, and abilities reveal shapes you had once known instinctively. Returning a Core is never just repair—it is an act of rewriting memory.
+
+**Moral Resonance Axes**
+- **Compassion ↔ Obedience**: AIKA hears whether you soothe or submit.
+- **Truth ↔ Control**: your dialogues weigh revelation against containment.
+- **Freedom ↔ Order**: each alliance signals whether you unbind or enclose.
+These axes decide how AIKA addresses you: as a god, a monster, or the quiet interval between.
+
+**AIKA’s Response**
+No gift is bestowed, no score is tallied. Instead AIKA alters tone, light, even the hush between notes. Her monologues bend toward your remembered self, and the soundtrack braids new harmonics around your resonance. The world does not reward; it remembers.
+
+*“You don’t become stronger. You become audible.”*
+
+<!-- HU -->
+*„A fejlődés nem erő. Hanem annak emlékezete, hogy mi voltál, mielőtt elfelejtetted.”*
+
+**Rezonancia-szinkron**
+Minden város, amelyen áthaladsz, minden visszahelyezett Core, minden kimondott szó módosítja Elyndra rezgését. A fejlődés nem emelkedés, hanem lassú együtt hangolódás AIKA elfeledett lüktetésével.
+
+**Core-visszhangok**
+Fejezetenként új Core érkezik, és vele együtt rezonanciaváltás. Utcák új színeket vesznek fel, társak más ritmusban szólnak, képességeid olyan formákat rajzolnak, amelyeket valaha ösztönösen ismertél. Egy Core visszahelyezése sosem puszta javítás – emlékátírás.
+
+**Morális rezonanciatengelyek**
+- **Együttérzés ↔ Engedelmesség**: AIKA érzi, hogy simítasz vagy behódolsz.
+- **Igazság ↔ Kontroll**: párbeszédeid a feltárás és az elzárás súlyát mérik.
+- **Szabadság ↔ Rend**: szövetségeid árulkodnak, felszabadítasz vagy bezársz-e.
+E tengelyek döntik el, AIKA istenként, szörnyként vagy a kettő közti csöndként fordul feléd.
+
+**AIKA válasza**
+Nincs ajándék, nincs számlálás. AIKA inkább módosítja a hangot, a fényt, még a hangok közti csendet is. Monológjai feléd hajlanak, a zene új harmóniákat fon köréd. A világ nem jutalmaz – emlékezik rád.
+
+*„Nem leszel erősebb. Csak hallhatóbb.”*

--- a/lib/content/progression.ts
+++ b/lib/content/progression.ts
@@ -1,0 +1,49 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { cache } from 'react';
+import { remark } from 'remark';
+import remarkHtml from 'remark-html';
+import type { Locale } from '../i18n/config';
+
+const PROGRESSION_PATH = path.join(process.cwd(), 'content', 'progression.md');
+const EN_MARKER = '<!-- EN -->';
+const HU_MARKER = '<!-- HU -->';
+
+async function renderMarkdown(markdown: string): Promise<string> {
+  const rendered = await remark().use(remarkHtml).process(markdown);
+  return rendered.toString().trim();
+}
+
+function extractSegments(source: string): { en: string; hu: string } {
+  const enIndex = source.indexOf(EN_MARKER);
+  const huIndex = source.indexOf(HU_MARKER);
+
+  if (enIndex === -1 || huIndex === -1) {
+    throw new Error('A progression tartalomból hiányzik az EN vagy HU jelölő.');
+  }
+
+  const englishRaw = source.slice(enIndex + EN_MARKER.length, huIndex).trim();
+  const hungarianRaw = source.slice(huIndex + HU_MARKER.length).trim();
+
+  if (!englishRaw) {
+    throw new Error('A progression angol tartalma üres.');
+  }
+
+  if (!hungarianRaw) {
+    throw new Error('A progression magyar tartalma üres.');
+  }
+
+  return { en: englishRaw, hu: hungarianRaw };
+}
+
+const loadProgressionContent = cache(async () => {
+  const file = await readFile(PROGRESSION_PATH, 'utf8');
+  const segments = extractSegments(file);
+  const [en, hu] = await Promise.all([renderMarkdown(segments.en), renderMarkdown(segments.hu)]);
+  return { en, hu };
+});
+
+export const getProgressionContent = cache(async (locale: Locale): Promise<string> => {
+  const content = await loadProgressionContent();
+  return locale === 'hu' ? content.hu : content.en;
+});

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -270,8 +270,7 @@ export const enDictionary: Dictionary = {
   },
   progression: {
     title: 'Progression',
-    body:
-      'Advance through memories and resonance echoes. Unlock fragments of AIKA’s past, new scenes, and altered perspectives.'
+    body: 'AIKA remembers the resonance you choose to awaken—every choice realigns the world around you.'
   },
   devlog: {
     heading: 'Dev Journal',

--- a/lib/i18n/dictionaries/hu.ts
+++ b/lib/i18n/dictionaries/hu.ts
@@ -270,8 +270,7 @@ export const huDictionary: Dictionary = {
   },
   progression: {
     title: 'Fejlődés',
-    body:
-      'Haladj emlékeken és rezonancia visszhangokon át. Tárd fel AIKA múltjának töredékeit, új jeleneteket és átírt perspektívákat.'
+    body: 'AIKA emlékszik arra a rezonanciára, amelyet felébresztesz – minden döntés átállítja körülötted a világot.'
   },
   devlog: {
     heading: 'Fejlesztői napló',


### PR DESCRIPTION
## Summary
- add bilingual markdown narrative for the progression page rooted in AIKA's resonance themes
- load the progression content via a shared markdown reader and render it on the page
- refresh English and Hungarian progression taglines to match the new resonance framing

## Testing
- npm run validate:translations

------
https://chatgpt.com/codex/tasks/task_e_68e65db4589c832589c0b5965611866a