### PR TITLE
Fix progression page build failure on edge runtime

### DIFF
--- a/app/(marketing)/progression/page.tsx
+++ b/app/(marketing)/progression/page.tsx
@@ -6,6 +6,8 @@ import { createStaticPageMetadata } from '../../../lib/seo';
 import { locales } from '../../../lib/i18n/config';
 import { getProgressionContent } from '../../../lib/content/progression';
 
+export const runtime = 'nodejs';
+
 export function generateStaticParams(): Record<string, never>[] {
   return locales.map(() => ({}));
 }


### PR DESCRIPTION
## Summary
- set the progression marketing page to use the Node.js runtime so it can access filesystem APIs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e660e0cef08325aecfcdae6a448e5c